### PR TITLE
Undefined fields validator

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/plugins/validators/undefined_fields/__init__.py
+++ b/python/src/aac/plugins/validators/undefined_fields/__init__.py
@@ -1,0 +1,32 @@
+"""Validation plugin to ensure that each definition has only fields that are defined in its schema."""
+
+from aac.plugins import hookimpl
+from aac.plugins.plugin import Plugin
+from aac.plugins._common import get_plugin_definitions_from_yaml
+from aac.plugins.validators._common import get_plugin_validations_from_definitions
+from aac.plugins.validators.undefined_fields._validate_undefined_fields import (
+    PLUGIN_NAME,
+    validate_undefined_fields,
+)
+
+
+@hookimpl
+def get_plugin() -> Plugin:
+    """
+    Returns information about the plugin.
+
+    Returns:
+        A collection of information about the plugin and what it contributes.
+    """
+    plugin = Plugin(PLUGIN_NAME)
+    plugin.register_definitions(_get_plugin_definitions())
+    plugin.register_definition_validations(_get_plugin_validations())
+    return plugin
+
+
+def _get_plugin_definitions():
+    return get_plugin_definitions_from_yaml(__package__, "undefined_fields.yaml")
+
+
+def _get_plugin_validations():
+    return get_plugin_validations_from_definitions(_get_plugin_definitions(), validate_undefined_fields)

--- a/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
+++ b/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Any
+
+from aac.lang.constants import DEFINITION_FIELD_FIELDS, DEFINITION_FIELD_NAME, DEFINITION_FIELD_TYPE
+from aac.lang.definitions.definition import Definition
+from aac.lang.definitions.structure import get_substructures_by_type
+from aac.lang.definitions.type import is_array_type
+from aac.lang.language_context import LanguageContext
+from aac.plugins.validators import ValidatorFindings, ValidatorResult
+
+
+PLUGIN_NAME = "Validate undefined fields"
+VALIDATION_NAME = "Disallow undefined fields"
+
+
+def validate_undefined_fields(
+    definition_under_test: Definition,
+    target_schema_definition: Definition,
+    language_context: LanguageContext,
+    *validation_args,
+) -> ValidatorResult:
+    """
+    Validates that the definition only has fields present that are defined in its defined schema.
+
+    Args:
+        definition_under_test (Definition): The definition that's being validated.
+        target_schema_definition (Definition): A definition with applicable validation.
+        language_context (LanguageContext): The language context.
+        *validation_args: The names of the required fields.
+
+    Returns:
+        A ValidatorResult containing any applicable error messages.
+    """
+    findings = ValidatorFindings()
+
+    def validate_dict(dict_to_validate: dict) -> None:
+        defined_field_names = list(target_schema_definition.get_top_level_fields().keys())
+
+        # Iterate through the dict keys as those are the field names
+        for field_name in dict_to_validate.keys():
+            if field_name not in defined_field_names:
+                undefined_field_message = f"Field '{field_name}' is not one of the fields {defined_field_names} defined in '{target_schema_definition.name}'."
+                findings.add_error_finding(
+                    definition_under_test, undefined_field_message, VALIDATION_NAME, definition_under_test.get_lexeme_with_value(field_name)
+                )
+
+    dicts_to_test = get_substructures_by_type(definition_under_test, target_schema_definition, language_context)
+    list(map(validate_dict, dicts_to_test))
+
+    return ValidatorResult([definition_under_test], findings)

--- a/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
+++ b/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Any
+from aac.lang.constants import DEFINITION_FIELD_NAME
 
-from aac.lang.constants import DEFINITION_FIELD_FIELDS, DEFINITION_FIELD_NAME, DEFINITION_FIELD_TYPE
 from aac.lang.definitions.definition import Definition
 from aac.lang.definitions.structure import get_substructures_by_type
-from aac.lang.definitions.type import is_array_type
 from aac.lang.language_context import LanguageContext
+from aac.lang.definitions.schema import get_definition_schema
 from aac.plugins.validators import ValidatorFindings, ValidatorResult
 
 
@@ -34,12 +33,16 @@ def validate_undefined_fields(
     findings = ValidatorFindings()
 
     def validate_dict(dict_to_validate: dict) -> None:
-        defined_field_names = list(target_schema_definition.get_top_level_fields().keys())
+        # Due to a bug in how global validations are currently being applied, we need to look up the schema rather
+        #   than rely on the schema provided by the validation system.
+        definition_schema = get_definition_schema(definition_under_test, language_context)
+        defined_field_names = [field.get(DEFINITION_FIELD_NAME) for field in definition_schema.get_fields()]
 
         # Iterate through the dict keys as those are the field names
         for field_name in dict_to_validate.keys():
             if field_name not in defined_field_names:
-                undefined_field_message = f"Field '{field_name}' is not one of the fields {defined_field_names} defined in '{target_schema_definition.name}'."
+                undefined_field_message = f"Field '{field_name}' is not one of the fields {defined_field_names} defined in '{definition_schema.name}'."
+                logging.error(undefined_field_message)
                 findings.add_error_finding(
                     definition_under_test, undefined_field_message, VALIDATION_NAME, definition_under_test.get_lexeme_with_value(field_name)
                 )

--- a/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
+++ b/python/src/aac/plugins/validators/undefined_fields/_validate_undefined_fields.py
@@ -41,7 +41,7 @@ def validate_undefined_fields(
         # Iterate through the dict keys as those are the field names
         for field_name in dict_to_validate.keys():
             if field_name not in defined_field_names:
-                undefined_field_message = f"Field '{field_name}' is not one of the fields {defined_field_names} defined in '{definition_schema.name}'."
+                undefined_field_message = f"Field '{field_name}' is not one of the fields defined in '{definition_schema.name}'."
                 logging.error(undefined_field_message)
                 findings.add_error_finding(
                     definition_under_test, undefined_field_message, VALIDATION_NAME, definition_under_test.get_lexeme_with_value(field_name)

--- a/python/src/aac/plugins/validators/undefined_fields/undefined_fields.yaml
+++ b/python/src/aac/plugins/validators/undefined_fields/undefined_fields.yaml
@@ -1,0 +1,39 @@
+plugin:
+  name: Validate undefined fields
+  description: An AaC plugin that enables validating that only fields defined via the schema are present.
+  definitionValidations:
+    - name: Disallow undefined fields
+---
+validation:
+  name: Disallow undefined fields
+  description: Verify every field present is declared by the definition's schema.
+  behavior:
+    - name: Verify that present fields as defined via the definition's schema.
+      type: REQUEST_RESPONSE
+      input:
+        - name: input
+          type: ValidatorInput
+      output:
+        - name: results
+          type: ValidatorOutput
+      acceptance:
+        - scenario: Successfully validate that a definition's present fields are defined.
+          given:
+            - The ValidatorInput content consists of valid AaC definitions.
+            - The ValidatorInput contains AaC definitions that only fields that are defined in the definition's schema.
+          when:
+            - The validator plugin is executed.
+          then:
+            - The ValidatorOutput does not indicate any errors.
+            - The ValidatorOutput does not indicate any warnings.
+            - The ValidatorOutput indicates the validator plugin under test is valid.
+        - scenario: Fail to validate that a definition's present fields are defined.
+          given:
+            - The ValidatorInput content consists of otherwise valid AaC definitions.
+            - The ValidatorInput contains at least one field that is required.
+            - The ValidatorInput at least one AaC definition that has fields that are not defined in the definition's schema.
+          when:
+            - The validator plugin is executed.
+          then:
+            - The ValidatorOutput has errors.
+            - The ValidatorOutput errors indicate that there are undefined fields present.

--- a/python/src/aac/plugins/validators/undefined_fields/undefined_fields.yaml
+++ b/python/src/aac/plugins/validators/undefined_fields/undefined_fields.yaml
@@ -31,7 +31,7 @@ validation:
           given:
             - The ValidatorInput content consists of otherwise valid AaC definitions.
             - The ValidatorInput contains at least one field that is required.
-            - The ValidatorInput at least one AaC definition that has fields that are not defined in the definition's schema.
+            - The ValidatorInput contains one or more AaC definitions that has fields that are not defined in the definition's schema.
           when:
             - The validator plugin is executed.
           then:

--- a/python/src/aac/spec/spec.yaml
+++ b/python/src/aac/spec/spec.yaml
@@ -17,7 +17,7 @@ schema:
   root: enum
   description: |
     A definition that represents an enumerated type of value.
-    
+
     An example of when to use an 'enum' is when you want to provide several
     different options for a single value.
   fields:
@@ -40,11 +40,11 @@ schema:
   root: ext
   description: |
     A meta definition used for adding information to another definition.
-    
+
     An example of when to use an 'ext' is when you wish to add extra
     information to a model that isn't included in the core specification or
     the specification of any plugins you may have installed.
-    
+
     You can extend any 'enum' and 'schema' definition.
   fields:
     - name: name
@@ -121,7 +121,7 @@ schema:
     verification and validation for the definition to which they are
     attached and any uses of that definition, depending on the validation
     plugins referenced by it.
-    
+
     Validators are referenced by name.
   fields:
     - name: name
@@ -260,7 +260,7 @@ schema:
   root: schema
   description: |
     A definition that defines the schema/structure of definitions.
-    
+
     A 'schema' definition can alternatively be thought as a defining the
     data structure of a definition.
   fields:
@@ -290,6 +290,7 @@ schema:
         A list of requirements that define the characteristics to be satisfied by the schema.
   validation:
     - name: Root key is defined
+    - name: Disallow undefined fields
     - name: Required fields are present
       arguments:
         - name
@@ -348,7 +349,7 @@ schema:
   root: model
   description: |
     A definition that represents a system and/or component model.
-    
+
     An example of when to use a 'model' is when you want to define the
     behavior for some component of the system.
   fields:
@@ -391,7 +392,7 @@ schema:
   root: usecase
   description: |
     A definition that represents a usecase for the system.
-    
+
     An example of when to use a 'usecase' is when you want to define how the
     system might be used in a particular instance.
   fields:
@@ -482,7 +483,7 @@ schema:
   description: |
     A reference to a command group under which one, or more, plugins can
     nest related commands.
-    
+
     CommandGroups are referenced by name.
   fields:
     - name: name
@@ -552,7 +553,7 @@ schema:
     A reference to a plugin. Plugins can provide any extra functionality
     desired on top of AaC-modeled systems from document generation to code
     generation and everything in between.
-    
+
     Plugins are referenced by name.
   fields:
     - name: name
@@ -603,7 +604,7 @@ schema:
   root: spec
   description: |
     A requirement specification definition to capture desired behavior or attributes of the system being modeled.
-    
+
     Within many contexts requirements remain the central element of any Model-Based System Engineering solution.
     AaC supports the definition, derivation, and trace of requirements throughout the model using the spec type and
     associated reference capabilities.

--- a/python/src/aac/spec/spec.yaml
+++ b/python/src/aac/spec/spec.yaml
@@ -272,6 +272,10 @@ schema:
       type: string
       description: |
         The yaml key used to represent the type when defined at the root of the AaC model file.
+    - name: description
+      type: string
+      description: |
+        Allows users to add some text to describe their definition.
     - name: inherits
       type: reference[]
       description: |
@@ -617,8 +621,6 @@ schema:
       type: SpecSection[]
     - name: requirements
       type: Requirement[]
-  required:
-    - name
   validation:
     - name: Required fields are present
       arguments:
@@ -633,8 +635,6 @@ schema:
       type: string
     - name: requirements
       type: Requirement[]
-  required:
-    - name
   validation:
     - name: Required fields are present
       arguments:
@@ -653,9 +653,6 @@ schema:
       type: RequirementReference
     - name: attributes
       type: RequirementAttribute[]
-  required:
-    - id
-    - shall
   validation:
     - name: Required fields are present
       arguments:
@@ -672,9 +669,6 @@ schema:
       type: string
     - name: value
       type: string
-  required:
-    - name
-    - value
   validation:
     - name: Required fields are present
       arguments:
@@ -686,8 +680,6 @@ schema:
   fields:
     - name: ids
       type: string[]
-  required:
-    - ids
   validation:
     - name: Required fields are present
       arguments:

--- a/python/tests/lang/definitions/test_json_schema.py
+++ b/python/tests/lang/definitions/test_json_schema.py
@@ -66,7 +66,7 @@ EXPECTED_SCHEMA_JSON_SCHEMA = """
             "type": "string"
         },
         "description": {
-                        "type": "string"
+            "type": "string"
         },
         "fields": {
             "type": "array",

--- a/python/tests/lang/definitions/test_json_schema.py
+++ b/python/tests/lang/definitions/test_json_schema.py
@@ -65,6 +65,9 @@ EXPECTED_SCHEMA_JSON_SCHEMA = """
         "root": {
             "type": "string"
         },
+        "description": {
+                        "type": "string"
+        },
         "fields": {
             "type": "array",
             "items":

--- a/python/tests/plugins/validators/test__validate_undefined_fields.py
+++ b/python/tests/plugins/validators/test__validate_undefined_fields.py
@@ -1,0 +1,79 @@
+from aac.io.parser import parse
+from aac.lang.active_context_lifecycle_manager import get_active_context
+from aac.lang.constants import (
+    DEFINITION_NAME_SCHEMA,
+    PRIMITIVE_TYPE_STRING,
+    ROOT_KEY_SCHEMA,
+)
+from aac.plugins.validators.undefined_fields._validate_undefined_fields import validate_undefined_fields, VALIDATION_NAME
+from aac.validate import validated_definition, ValidationError
+
+from tests.active_context_test_case import ActiveContextTestCase
+from tests.helpers.parsed_definitions import (
+    create_field_entry,
+    create_schema_definition,
+)
+
+
+class TestUndefinedFieldsPlugin(ActiveContextTestCase):
+
+    def test_validate_undefined_fields_invalid(self):
+
+        # Create a test schema with a field `notADefinedFieldName` that is not defined in the `Schema` definition's fields.
+        undefined_schema_field_name = "notADefinedFieldName"
+        undefined_schema_field_value = "testString"
+        test_schema_definition = create_schema_definition("TestSchema")
+
+        # Manually insert the undefined field into the test definition's structure
+        test_schema_definition.structure[ROOT_KEY_SCHEMA][undefined_schema_field_name] = undefined_schema_field_value
+
+        # Re-parsing the test definition since the undefined field wasn't present when lexemes were calculated.
+        test_schema_definition, *_ = parse(test_schema_definition.to_yaml())
+        test_context = get_active_context()
+
+        # Get the `Schema` definition since that defines the structure for all `schema` definitions.
+        schema_definition = test_context.get_definition_by_name(DEFINITION_NAME_SCHEMA)
+
+        result = validate_undefined_fields(test_schema_definition, schema_definition, test_context)
+        self.assertFalse(result.is_valid())
+
+    def test_validate_undefined_fields_valid(self):
+
+        # Create a valid instance of a schema definition.
+        valid_schema_field = create_field_entry("someValidFieldEntry", PRIMITIVE_TYPE_STRING)
+        test_schema_definition = create_schema_definition("TestSchema", fields=[valid_schema_field])
+
+        test_context = get_active_context()
+
+        # Get the `Schema` definition since that defines the structure for all `schema` definitions.
+        schema_definition = test_context.get_definition_by_name(DEFINITION_NAME_SCHEMA)
+
+        result = validate_undefined_fields(test_schema_definition, schema_definition, test_context)
+        self.assertTrue(result.is_valid())
+
+    def test_validate_invalid_with_undefined_field_present(self):
+
+        # Create a test schema with a field `notADefinedFieldName` that is not defined in the `Schema` definition's fields.
+        undefined_schema_field_name = "notADefinedFieldName"
+        undefined_schema_field_value = "testString"
+
+        test_field = create_field_entry("testField", PRIMITIVE_TYPE_STRING)
+        test_schema_definition = create_schema_definition("TestSchema", fields=[test_field])
+
+        # Manually insert the undefined field into the test definition's structure
+        test_schema_definition.structure[ROOT_KEY_SCHEMA][undefined_schema_field_name] = undefined_schema_field_value
+
+        # Re-parsing the test definition since the undefined field wasn't present when lexemes were calculated.
+        test_schema_definition, *_ = parse(test_schema_definition.to_yaml())
+
+        validation_error = None
+        try:
+            with validated_definition(test_schema_definition):
+                pass
+        except Exception as error:
+            validation_error = error
+        finally:
+            self.assertIsInstance(validation_error, ValidationError)
+            self.assertIn(undefined_schema_field_name, str(validation_error))
+            self.assertIn(VALIDATION_NAME, str(validation_error))
+

--- a/python/tests/plugins/validators/test__validate_undefined_fields.py
+++ b/python/tests/plugins/validators/test__validate_undefined_fields.py
@@ -76,4 +76,3 @@ class TestUndefinedFieldsPlugin(ActiveContextTestCase):
             self.assertIsInstance(validation_error, ValidationError)
             self.assertIn(undefined_schema_field_name, str(validation_error))
             self.assertIn(VALIDATION_NAME, str(validation_error))
-


### PR DESCRIPTION
# Description

Added a new validator that returns an error if there is a field present that isn't defined. 

# Linked Items:

Closes #429 

### Added

- Added a new validator that returns an error if there is a field present that isn't defined by the schema definition. 

### Changed

- _Describe any changes in existing functionality._

### Deprecated

- _Describe any deprecated features._

### Removed

- _Describe any removed features._

### Fixed

- Added a new description field to schema definitions to accommodate previous changes in the core spec
- Removed some errant `required` fields that were present

### Security

- _Describe any security-related changes._

# Checklist:

- [X] I updated project documentation to reflect my changes.
- [X] My changes generate no new warnings.
- [X] I updated new and existing unit tests to account for my changes.
- [X] I linked the associated item(s) to be closed.
- [X] I bumped the version.
