### PR TITLE
Create usecase action references validator

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.3.3"
+__version__ = "0.3.6"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/plugins/validators/usecase_actions/__init__.py
+++ b/python/src/aac/plugins/validators/usecase_actions/__init__.py
@@ -1,0 +1,31 @@
+"""An AaC plugin that validates usecase actions are defined behaviors."""
+
+from aac.plugins import hookimpl
+from aac.plugins import Plugin, get_plugin_definitions_from_yaml
+from aac.plugins.validators.usecase_actions._validate_usecase_actions import (
+    PLUGIN_NAME,
+    validate_usecase_actions,
+)
+from aac.plugins.validators import get_plugin_validations_from_definitions
+
+
+@hookimpl
+def get_plugin() -> Plugin:
+    """
+    Returns information about the plugin.
+
+    Returns:
+        A collection of information about the plugin and what it contributes.
+    """
+    plugin = Plugin(PLUGIN_NAME)
+    plugin.register_definitions(_get_plugin_definitions())
+    plugin.register_definition_validations(_get_plugin_validations())
+    return plugin
+
+
+def _get_plugin_definitions():
+    return get_plugin_definitions_from_yaml(__package__, "usecase_actions.yaml")
+
+
+def _get_plugin_validations():
+    return get_plugin_validations_from_definitions(_get_plugin_definitions(), validate_usecase_actions)

--- a/python/src/aac/plugins/validators/usecase_actions/_validate_usecase_actions.py
+++ b/python/src/aac/plugins/validators/usecase_actions/_validate_usecase_actions.py
@@ -1,0 +1,58 @@
+import logging
+
+from aac.lang.constants import (
+    DEFINITION_FIELD_ACTION,
+    DEFINITION_FIELD_BEHAVIOR,
+    DEFINITION_FIELD_NAME,
+    DEFINITION_FIELD_SOURCE,
+    DEFINITION_FIELD_STEPS,
+    ROOT_KEY_USECASE,
+)
+from aac.lang.definitions.definition import Definition
+from aac.lang.language_context import LanguageContext
+from aac.plugins.validators import ValidatorFindings, ValidatorResult
+
+PLUGIN_NAME: str = "Validate usecase actions"
+VALIDATION_NAME: str = "Usecase actions refer to defined model behaviors"
+
+
+def validate_usecase_actions(
+    definition_under_test: Definition,
+    target_schema_definition: Definition,
+    language_context: LanguageContext,
+    *validation_args,
+) -> ValidatorResult:
+    """
+    Validates that the usecase action field refers to a defined model behavior.
+
+    Args:
+        definition_under_test (Definition): The definition that's being validated.
+        target_schema_definition (Definition): A definition with applicable validation.
+        language_context (LanguageContext): The language context.
+
+    Returns:
+        A ValidatorResult containing any applicable error messages.
+    """
+    findings = ValidatorFindings()
+
+    if definition_under_test.get_root_key() == ROOT_KEY_USECASE:
+        fields = definition_under_test.get_top_level_fields()
+        for step in fields.get(DEFINITION_FIELD_STEPS, []):
+            action_name = step.get(DEFINITION_FIELD_ACTION)
+            source_name = step.get(DEFINITION_FIELD_SOURCE)
+            source = language_context.get_definition_by_name(source_name)
+            source_behaviors = source.get_top_level_fields().get(DEFINITION_FIELD_BEHAVIOR, [])
+            if action_name not in [field.get(DEFINITION_FIELD_NAME) for field in source_behaviors]:
+                invalid_action_reference_message = f"Action '{action_name}' does not refer to a behavior in '{source_name}'."
+                logging.error(invalid_action_reference_message)
+                findings.add_error_finding(
+                    definition_under_test,
+                    invalid_action_reference_message,
+                    VALIDATION_NAME,
+                    definition_under_test.get_lexeme_with_value(action_name),
+                )
+
+    else:
+        logging.warn(f"Definition {definition_under_test.name} is not a {ROOT_KEY_USECASE}")
+
+    return ValidatorResult([definition_under_test], findings)

--- a/python/src/aac/plugins/validators/usecase_actions/usecase_actions.yaml
+++ b/python/src/aac/plugins/validators/usecase_actions/usecase_actions.yaml
@@ -1,0 +1,36 @@
+plugin:
+  name: Validate usecase actions
+  description: An AaC plugin that validates usecase actions are defined behaviors.
+  definitionValidations:
+    - name: Usecase actions are defined behaviors
+---
+validation:
+  name: Usecase actions are defined behaviors
+  description: Verify that the action field of a usecase definition refers to a valid model behavior.
+  behavior:
+    - name: Verify that the action field of a usecase definition refers to a defined model behavior.
+      type: REQUEST_RESPONSE
+      input:
+        - name: input
+          type: ValidatorInput
+      output:
+        - name: results
+          type: ValidatorOutput
+      acceptance:
+        - scenario: Verify that the action field of a usecase refers to a defined model behavior in the source model.
+          given:
+            - The ValidatorInput content consists of an action field that refers to a defined behavior in the source participant model.
+          when:
+            - The validator plugin is executed.
+          then:
+            - The ValidatorOutput does not indicate any errors.
+            - The ValidatorOutput does not indicate any warnings.
+            - The ValidatorOutput indicates the definition under test is valid.
+        - scenario: Fail to validate usecase participant with invalid action.
+          given:
+            - The ValidatorInput content consists of an action field that does not refer to a defined behavior in the source model.
+          when:
+            - The validator plugin is executed.
+          then:
+            - The ValidatorOutput has errors.
+            - The ValidatorOutput errors indicate that there is no corresponding behavior in the source model.

--- a/python/src/aac/plugins/validators/usecase_actions/usecase_actions.yaml
+++ b/python/src/aac/plugins/validators/usecase_actions/usecase_actions.yaml
@@ -2,10 +2,10 @@ plugin:
   name: Validate usecase actions
   description: An AaC plugin that validates usecase actions are defined behaviors.
   definitionValidations:
-    - name: Usecase actions are defined behaviors
+    - name: Usecase actions refer to defined model behaviors
 ---
 validation:
-  name: Usecase actions are defined behaviors
+  name: Usecase actions refer to defined model behaviors
   description: Verify that the action field of a usecase definition refers to a valid model behavior.
   behavior:
     - name: Verify that the action field of a usecase definition refers to a defined model behavior.

--- a/python/src/aac/spec/spec.yaml
+++ b/python/src/aac/spec/spec.yaml
@@ -424,6 +424,7 @@ schema:
         - participants
         - steps
     - name: Usecase sources and targets refer to defined participants
+    - name: Usecase actions refer to defined model behaviors
 ---
 schema:
   name: Step

--- a/python/src/aac/spec/spec.yaml
+++ b/python/src/aac/spec/spec.yaml
@@ -17,7 +17,7 @@ schema:
   root: enum
   description: |
     A definition that represents an enumerated type of value.
-    
+
     An example of when to use an 'enum' is when you want to provide several
     different options for a single value.
   fields:
@@ -40,11 +40,11 @@ schema:
   root: ext
   description: |
     A meta definition used for adding information to another definition.
-    
+
     An example of when to use an 'ext' is when you wish to add extra
     information to a model that isn't included in the core specification or
     the specification of any plugins you may have installed.
-    
+
     You can extend any 'enum' and 'schema' definition.
   fields:
     - name: name
@@ -121,7 +121,7 @@ schema:
     verification and validation for the definition to which they are
     attached and any uses of that definition, depending on the validation
     plugins referenced by it.
-    
+
     Validators are referenced by name.
   fields:
     - name: name
@@ -260,7 +260,7 @@ schema:
   root: schema
   description: |
     A definition that defines the schema/structure of definitions.
-    
+
     A 'schema' definition can alternatively be thought as a defining the
     data structure of a definition.
   fields:
@@ -348,7 +348,7 @@ schema:
   root: model
   description: |
     A definition that represents a system and/or component model.
-    
+
     An example of when to use a 'model' is when you want to define the
     behavior for some component of the system.
   fields:
@@ -391,7 +391,7 @@ schema:
   root: usecase
   description: |
     A definition that represents a usecase for the system.
-    
+
     An example of when to use a 'usecase' is when you want to define how the
     system might be used in a particular instance.
   fields:
@@ -482,7 +482,7 @@ schema:
   description: |
     A reference to a command group under which one, or more, plugins can
     nest related commands.
-    
+
     CommandGroups are referenced by name.
   fields:
     - name: name
@@ -552,7 +552,7 @@ schema:
     A reference to a plugin. Plugins can provide any extra functionality
     desired on top of AaC-modeled systems from document generation to code
     generation and everything in between.
-    
+
     Plugins are referenced by name.
   fields:
     - name: name
@@ -603,7 +603,7 @@ schema:
   root: spec
   description: |
     A requirement specification definition to capture desired behavior or attributes of the system being modeled.
-    
+
     Within many contexts requirements remain the central element of any Model-Based System Engineering solution.
     AaC supports the definition, derivation, and trace of requirements throughout the model using the spec type and
     associated reference capabilities.

--- a/python/tests/helpers/parsed_definitions.py
+++ b/python/tests/helpers/parsed_definitions.py
@@ -156,7 +156,12 @@ def create_enum_definition(name: str, values: list[str]):
 
 
 def create_schema_definition(
-    name: str, root: str = "", description: str = "", fields: list[dict] = [], validations: list[dict] = [], inherits: list[str] = []
+    name: str,
+    root: str = "",
+    description: str = "",
+    fields: list[dict] = [],
+    validations: list[dict] = [],
+    inherits: list[str] = [],
 ):
     """Return a simulated schema definition."""
     definition_dict = {DEFINITION_FIELD_NAME: name}
@@ -179,7 +184,7 @@ def create_schema_definition(
     return create_definition(ROOT_KEY_SCHEMA, name, definition_dict)
 
 
-def create_usecase_definition(name: str, description: str, participants: list[dict] = [], steps: list[dict] = []):
+def create_usecase_definition(name: str, description: str = "", participants: list[dict] = [], steps: list[dict] = []):
     """Return a simulated usecase definition."""
     definition_dict = {
         DEFINITION_FIELD_NAME: name,

--- a/python/tests/plugins/first_party/test_gen_design_doc_impl.py
+++ b/python/tests/plugins/first_party/test_gen_design_doc_impl.py
@@ -77,6 +77,7 @@ class TestGenerateDesignDocumentPlugin(ActiveContextTestCase):
         [self.assertIn(pattern, markdown) for pattern in patterns]
 
 
+TEST_BEHAVIOR_NAME = "do something great"
 TEST_MODEL = f"""
 schema:
   name: Vector
@@ -114,7 +115,7 @@ model:
   name: test model
   description: a system to do things
   behavior:
-    - name: do something great
+    - name: {TEST_BEHAVIOR_NAME}
       description: have the system do something great
       type: {BEHAVIOR_TYPE_PUBLISH_SUBSCRIBE}
       input:
@@ -163,11 +164,7 @@ usecase:
     - step: move an object from one place to another
       source: model1
       target: model2
-      action: move from point alpha to point beta
-    - step: move an object back to it's original location
-      source: model2
-      target: model1
-      action: move from point beta back to point alpha
+      action: {TEST_BEHAVIOR_NAME}
 """
 
 TEST_MODEL_2 = """

--- a/python/tests/plugins/first_party/test_gen_plant_uml.py
+++ b/python/tests/plugins/first_party/test_gen_plant_uml.py
@@ -100,7 +100,9 @@ class TestGenPlantUml(ActiveContextTestCase):
             assert_plugin_success(result)
 
             filename = _convert_aac_filepath_to_filename(plugin_yaml.name)
-            expected_puml_file_path = _get_generated_file_name(filename, OBJECT_STRING, TEST_PUML_SERVICE_TWO_TYPE, temp_directory)
+            expected_puml_file_path = _get_generated_file_name(
+                filename, OBJECT_STRING, TEST_PUML_SERVICE_TWO_TYPE, temp_directory
+            )
 
             temp_directory_files = os.listdir(full_output_dir)
 
@@ -280,6 +282,9 @@ TEST_PUML_DATA_B_TYPE = "DataB"
 TEST_PUML_DATA_C_TYPE = "DataC"
 TEST_PUML_USE_CASE_ONE_TITLE = "Nominal flow within the system usecase one."
 TEST_PUML_USE_CASE_TWO_TITLE = "Request/response flow usecase two."
+TEST_PUML_BEHAVIOR_ONE_NAME = f"Process {TEST_PUML_DATA_A_TYPE} Request to {TEST_PUML_DATA_C_TYPE} Response"
+TEST_PUML_BEHAVIOR_TWO_NAME = f"Process {TEST_PUML_DATA_A_TYPE} Request"
+TEST_PUML_BEHAVIOR_THREE_NAME = f"Process {TEST_PUML_DATA_B_TYPE} Request"
 
 TEST_PUML_ARCH_YAML = f"""
 model:
@@ -291,7 +296,7 @@ model:
     - name: {TEST_PUML_SERVICE_TWO_NAME}
       type: {TEST_PUML_SERVICE_TWO_TYPE}
   behavior:
-    - name: Process {TEST_PUML_DATA_A_TYPE} Request to {TEST_PUML_DATA_C_TYPE} Response
+    - name: {TEST_PUML_BEHAVIOR_ONE_NAME}
       type: {BEHAVIOR_TYPE_REQUEST_RESPONSE}
       description: process {TEST_PUML_DATA_A_TYPE} and respond with {TEST_PUML_DATA_C_TYPE}
       input:
@@ -316,7 +321,7 @@ model:
 model:
   name: {TEST_PUML_SERVICE_ONE_TYPE}
   behavior:
-    - name: Process {TEST_PUML_DATA_A_TYPE} Request
+    - name: {TEST_PUML_BEHAVIOR_TWO_NAME}
       type: {BEHAVIOR_TYPE_REQUEST_RESPONSE}
       description: Process a {TEST_PUML_DATA_A_TYPE} request and return a {TEST_PUML_DATA_B_TYPE} response
       input:
@@ -345,7 +350,7 @@ model:
 model:
   name: {TEST_PUML_SERVICE_TWO_TYPE}
   behavior:
-    - name: Process {TEST_PUML_DATA_B_TYPE} Request
+    - name: {TEST_PUML_BEHAVIOR_THREE_NAME}
       type: {BEHAVIOR_TYPE_REQUEST_RESPONSE}
       description: Process a {TEST_PUML_DATA_B_TYPE} request and return a {TEST_PUML_DATA_C_TYPE} response
       input:
@@ -396,15 +401,15 @@ usecase:
     - step: The system has been invoked to doFlow which triggers {TEST_PUML_SERVICE_ONE_NAME}
       source: {TEST_PUML_SYSTEM_NAME}
       target: {TEST_PUML_SERVICE_ONE_NAME}
-      action: ProcessDataA
+      action: {TEST_PUML_BEHAVIOR_ONE_NAME}
     - step: {TEST_PUML_SERVICE_ONE_NAME} completes and calls {TEST_PUML_SERVICE_TWO_NAME} to continue the flow
       source: {TEST_PUML_SERVICE_ONE_NAME}
       target: {TEST_PUML_SERVICE_TWO_NAME}
-      action: ProcessDataB
+      action: {TEST_PUML_BEHAVIOR_TWO_NAME}
     - step: svc3 completes and provides the result back to {TEST_PUML_SYSTEM_NAME}
       source: {TEST_PUML_SERVICE_TWO_NAME}
       target: {TEST_PUML_SYSTEM_NAME}
-      action: doFlow
+      action: {TEST_PUML_BEHAVIOR_THREE_NAME}
 ---
 usecase:
   name: {TEST_PUML_USE_CASE_TWO_TITLE}
@@ -418,9 +423,9 @@ usecase:
     - step: {TEST_PUML_SERVICE_ONE_NAME} makes a request for data from {TEST_PUML_SERVICE_TWO_NAME}
       source: {TEST_PUML_SERVICE_ONE_NAME}
       target: {TEST_PUML_SERVICE_TWO_NAME}
-      action: sendRequestToServiceTwo
+      action: {TEST_PUML_BEHAVIOR_TWO_NAME}
     - step: {TEST_PUML_SERVICE_TWO_NAME} completes and provides the result back to {TEST_PUML_SERVICE_ONE_NAME}
       source: {TEST_PUML_SERVICE_TWO_NAME}
       target: {TEST_PUML_SERVICE_ONE_NAME}
-      action: respondToServiceOne
+      action: {TEST_PUML_BEHAVIOR_THREE_NAME}
 """

--- a/python/tests/plugins/validators/test__validate_usecase_actions.py
+++ b/python/tests/plugins/validators/test__validate_usecase_actions.py
@@ -25,17 +25,14 @@ class TestValidateUsecaseActions(ActiveContextTestCase):
         test_model_1 = create_model_definition("SomeModel", behavior=[test_behavior_1, test_behavior_2])
         test_model_2 = create_model_definition("SomeOtherModel")
 
-        test_step_1 = create_step_entry(
-            "step1", test_model_1.name, test_model_2.name, test_behavior_1.get(DEFINITION_FIELD_NAME)
-        )
-        test_step_2 = create_step_entry(
-            "step2", test_model_1.name, test_model_2.name, test_behavior_2.get(DEFINITION_FIELD_NAME)
-        )
+        test_participants = [create_field_entry("user1", test_model_1.name), create_field_entry("user2", test_model_2.name)]
+        test_participant_names = [participant.get(DEFINITION_FIELD_NAME) for participant in test_participants]
+
+        test_step_1 = create_step_entry("step1", *test_participant_names, test_behavior_1.get(DEFINITION_FIELD_NAME))
+        test_step_2 = create_step_entry("step2", *test_participant_names, test_behavior_2.get(DEFINITION_FIELD_NAME))
 
         test_usecase = create_usecase_definition(
-            "TestUsecase",
-            participants=[create_field_entry(test_model_1.name), create_field_entry(test_model_2.name)],
-            steps=[test_step_1, test_step_2],
+            "TestUsecase", participants=test_participants, steps=[test_step_1, test_step_2]
         )
 
         test_active_context = get_active_context(reload_context=True)
@@ -53,9 +50,17 @@ class TestValidateUsecaseActions(ActiveContextTestCase):
         test_participant_1 = create_field_entry("user1", test_model_1.name)
         test_participant_2 = create_field_entry("user2", test_model_2.name)
         test_step_1 = create_step_entry(
-            "step1", test_model_1.name, test_model_2.name, test_behavior.get(DEFINITION_FIELD_NAME)
+            "step1",
+            test_participant_1.get(DEFINITION_FIELD_NAME),
+            test_participant_2.get(DEFINITION_FIELD_NAME),
+            test_behavior.get(DEFINITION_FIELD_NAME),
         )
-        test_step_2 = create_step_entry("step2", test_model_2.name, test_model_1.name, "another action")
+        test_step_2 = create_step_entry(
+            "step2",
+            test_participant_2.get(DEFINITION_FIELD_NAME),
+            test_participant_1.get(DEFINITION_FIELD_NAME),
+            "another action",
+        )
         test_usecase = create_usecase_definition(
             "TestUsecase", participants=[test_participant_1, test_participant_2], steps=[test_step_1, test_step_2]
         )

--- a/python/tests/plugins/validators/test__validate_usecase_actions.py
+++ b/python/tests/plugins/validators/test__validate_usecase_actions.py
@@ -1,0 +1,77 @@
+from aac.lang.active_context_lifecycle_manager import get_active_context
+from aac.lang.constants import (
+    DEFINITION_FIELD_ACTION,
+    DEFINITION_FIELD_NAME,
+    DEFINITION_FIELD_SOURCE,
+    DEFINITION_NAME_USECASE,
+)
+from aac.lang.definitions.collections import get_definition_by_name
+from aac.plugins.validators.usecase_actions._validate_usecase_actions import validate_usecase_actions
+
+from tests.active_context_test_case import ActiveContextTestCase
+from tests.helpers.parsed_definitions import (
+    create_behavior_entry,
+    create_field_entry,
+    create_model_definition,
+    create_step_entry,
+    create_usecase_definition,
+)
+
+
+class TestValidateUsecaseActions(ActiveContextTestCase):
+    def test_validate_usecase_with_referenced_behaviors(self):
+        test_behavior_1 = create_behavior_entry("behavior1")
+        test_behavior_2 = create_behavior_entry("behavior2")
+        test_model_1 = create_model_definition("SomeModel", behavior=[test_behavior_1, test_behavior_2])
+        test_model_2 = create_model_definition("SomeOtherModel")
+
+        test_step_1 = create_step_entry(
+            "step1", test_model_1.name, test_model_2.name, test_behavior_1.get(DEFINITION_FIELD_NAME)
+        )
+        test_step_2 = create_step_entry(
+            "step2", test_model_1.name, test_model_2.name, test_behavior_2.get(DEFINITION_FIELD_NAME)
+        )
+
+        test_usecase = create_usecase_definition(
+            "TestUsecase",
+            participants=[create_field_entry(test_model_1.name), create_field_entry(test_model_2.name)],
+            steps=[test_step_1, test_step_2],
+        )
+
+        test_active_context = get_active_context(reload_context=True)
+        test_active_context.add_definitions_to_context([test_usecase, test_model_1, test_model_2])
+        target_schema_definition = get_definition_by_name(DEFINITION_NAME_USECASE, test_active_context.definitions)
+
+        result = validate_usecase_actions(test_usecase, target_schema_definition, test_active_context)
+
+        self.assertTrue(result.is_valid())
+
+    def test_usecase_with_action_does_not_reference_source_model_behavior_fails(self):
+        test_behavior = create_behavior_entry("an action")
+        test_model_1 = create_model_definition("SomeModel")
+        test_model_2 = create_model_definition("SomeOtherModel", behavior=[test_behavior])
+        test_participant_1 = create_field_entry("user1", test_model_1.name)
+        test_participant_2 = create_field_entry("user2", test_model_2.name)
+        test_step_1 = create_step_entry(
+            "step1", test_model_1.name, test_model_2.name, test_behavior.get(DEFINITION_FIELD_NAME)
+        )
+        test_step_2 = create_step_entry("step2", test_model_2.name, test_model_1.name, "another action")
+        test_usecase = create_usecase_definition(
+            "TestUsecase", participants=[test_participant_1, test_participant_2], steps=[test_step_1, test_step_2]
+        )
+
+        test_active_context = get_active_context(reload_context=True)
+        test_active_context.add_definitions_to_context([test_usecase, test_model_1, test_model_2])
+        target_schema_definition = get_definition_by_name(DEFINITION_NAME_USECASE, test_active_context.definitions)
+
+        result = validate_usecase_actions(test_usecase, target_schema_definition, test_active_context)
+
+        self.assertFalse(result.is_valid())
+
+        action_name = test_step_1.get(DEFINITION_FIELD_ACTION)
+        source_name = test_step_1.get(DEFINITION_FIELD_SOURCE)
+        self.assertRegexpMatches(result.get_messages_as_string(), f".*{action_name}.*not.*behavior.*{source_name}.*")
+
+        action_name = test_step_2.get(DEFINITION_FIELD_ACTION)
+        source_name = test_step_2.get(DEFINITION_FIELD_SOURCE)
+        self.assertRegexpMatches(result.get_messages_as_string(), f".*{action_name}.*not.*behavior.*{source_name}.*")


### PR DESCRIPTION
# Description

Add a validator that ensures all of the `action` fields in `usecase` steps refer to a valid behavior in the `step`'s `source` model.

# Linked Items:

Closes #646 

### Added

- A new validator which validates the `action` field of each of a `usecase`'s `steps`.

### Changed

- Clean up whitespace from `spec.yaml`.

# Checklist:

- [x] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
