### PR TITLE
Remove version mismatch check from state file import

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/lang/language_context.py
+++ b/python/src/aac/lang/language_context.py
@@ -27,7 +27,6 @@ from aac.lang.definitions.definition import Definition
 from aac.lang.definitions.extensions import apply_extension_to_definition, remove_extension_from_definition
 from aac.lang.definitions.type import remove_list_type_indicator
 from aac.lang.language_error import LanguageError
-from aac.persistence.state_file_error import StateFileError
 from aac.plugins.contributions.contribution_points import DefinitionValidationContribution, PrimitiveValidationContribution
 from aac.plugins.plugin import Plugin
 from aac.plugins.plugin_manager import get_plugins

--- a/python/src/aac/lang/language_context.py
+++ b/python/src/aac/lang/language_context.py
@@ -623,12 +623,7 @@ class LanguageContext:
                 return object.get("aac_version"), object.get("plugins")
 
         if lexists(file_uri):
-            version, plugins = decode_state_file()
-
-            if version != __version__:
-                raise StateFileError(
-                    f"Version mismatch: State file written using version {version}; current AaC version {__version__}"
-                )
+            _, plugins = decode_state_file()
 
             # Make sure to clear the state of the context before importing a state file.
             self.clear()


### PR DESCRIPTION
# Description

Remove the version mismatch check from the state file import since it's not used and it's causing issues.

# Linked Items:

Nothing to link.

### Removed

- Version mismatch check.

# Checklist:

- [x] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
