### PR TITLE
Print Validated File List

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,9 +24,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout Repo
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
       - name: Set up Python 3.9

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -6,6 +6,11 @@ on:
   # Manual runs
   workflow_dispatch:
 
+# Configuring starting working directory
+defaults:
+  run:
+    working-directory: ./python
+
 # Set token permissions
 permissions:
   contents: read

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.3.13"
+__version__ = "0.3.15"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -45,6 +45,6 @@ class ValidatorResult:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
-            valid_files_output = "\n".join(f"The definitions in {definition_file}" for definition_file in definition_sources)
+            valid_files_output = "\nThe following definition files have been validated:\n" + "\n".join(definition_file for definition_file in definition_sources)
 
-        return valid_files_output + "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])
+        return valid_files_output + "\n" + "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -36,5 +36,9 @@ class ValidatorResult:
                 f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri} "
                 f"at {loc.location.line + 1}:{loc.location.column} {finding.message}"
             )
+        
+        if len(self.findings.get_error_findings()) == 0:
+            validated_defintions = self.definitions
+            return "\n".join(f"The definitions in {definition.source.uri}" for definition in validated_defintions)
 
         return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -43,7 +43,11 @@ class ValidatorResult:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
+<<<<<<< Updated upstream
             return "\n".join(f"The definitions in {definition_file} meet all validation constraints." for definition_file in definition_sources)
+=======
+            return "\n".join(f"The definitions in {definition.source.uri}" for definition in definition_sources)
+>>>>>>> Stashed changes
 
         else:
             return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -33,7 +33,8 @@ class ValidatorResult:
         def format_message(finding: ValidatorFinding) -> str:
             loc = finding.location
             return (
-                f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri}. {finding.message}"
+                f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri} "
+                f"at {loc.location.line + 1}:{loc.location.column} {finding.message}"
             )
 
         return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -43,7 +43,7 @@ class ValidatorResult:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
-            return "\n".join(f"The definitions in {definition.source.uri}" for definition in definition_sources)
+            return "\n".join(f"The definitions in {definition_file}" for definition_file in definition_sources)
 
         else:
             return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -45,6 +45,6 @@ class ValidatorResult:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
-            valid_files_output = "\nThe following definition files have been validated:\n" + "\n".join(definition_file for definition_file in definition_sources)
+            valid_files_output = "\nThe following additional definition files have been validated:\n" + "\n".join(definition_file for definition_file in definition_sources)
 
-        return valid_files_output + "\n" + "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])
+        return f"{valid_files_output}\n" + "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -36,9 +36,14 @@ class ValidatorResult:
                 f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri} "
                 f"at {loc.location.line + 1}:{loc.location.column} {finding.message}"
             )
-        
-        if len(self.findings.get_error_findings()) == 0:
-            validated_defintions = self.definitions
-            return "\n".join(f"The definitions in {definition.source.uri}" for definition in validated_defintions)
 
-        return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])
+        if len(self.findings.get_error_findings()) == 0:
+            definition_sources = []
+            for definition in self.definitions:
+                if definition.source.uri not in definition_sources:
+                    definition_sources.append(definition.source.uri)
+
+            return "\n".join(f"The definitions in {definition_file} meet all validation constraints." for definition_file in definition_sources)
+
+        else:
+            return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -37,13 +37,14 @@ class ValidatorResult:
                 f"at {loc.location.line + 1}:{loc.location.column} {finding.message}"
             )
 
-        if len(self.findings.get_error_findings()) == 0:
+        valid_files_output = ""
+
+        if self.is_valid():
             definition_sources = []
             for definition in self.definitions:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
-            return "\n".join(f"The definitions in {definition_file}" for definition_file in definition_sources)
+            valid_files_output = "\n".join(f"The definitions in {definition_file}" for definition_file in definition_sources)
 
-        else:
-            return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])
+        return valid_files_output + "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -33,8 +33,7 @@ class ValidatorResult:
         def format_message(finding: ValidatorFinding) -> str:
             loc = finding.location
             return (
-                f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri} "
-                f"at {loc.location.line + 1}:{loc.location.column} {finding.message}"
+                f"\nValidation {finding.severity.name} from '{loc.validation_name}' in {loc.source.uri}. {finding.message}"
             )
 
         return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/plugins/validators/_validator_result.py
+++ b/python/src/aac/plugins/validators/_validator_result.py
@@ -43,11 +43,7 @@ class ValidatorResult:
                 if definition.source.uri not in definition_sources:
                     definition_sources.append(definition.source.uri)
 
-<<<<<<< Updated upstream
-            return "\n".join(f"The definitions in {definition_file} meet all validation constraints." for definition_file in definition_sources)
-=======
             return "\n".join(f"The definitions in {definition.source.uri}" for definition in definition_sources)
->>>>>>> Stashed changes
 
         else:
             return "\n".join([format_message(finding) for finding in self.findings.get_all_findings()])

--- a/python/src/aac/validate/_validate.py
+++ b/python/src/aac/validate/_validate.py
@@ -78,8 +78,6 @@ def _with_validation(
         result = _validate_definitions(user_definitions, language_context, validate_context)
 
         if result.is_valid():
-            for definition in user_definitions:
-                print(f"The {definition.name} definition in {definition.source.uri} has been validated.")
             return result
         else:
             raise ValidationError(result.get_messages_as_string())

--- a/python/src/aac/validate/_validate.py
+++ b/python/src/aac/validate/_validate.py
@@ -78,9 +78,8 @@ def _with_validation(
         result = _validate_definitions(user_definitions, language_context, validate_context)
 
         if result.is_valid():
-            print("The following file(s) have been validated:")
             for definition in user_definitions:
-                print(definition.source.uri)
+                print(f"The {definition.name} definition in {definition.source.uri} has been validated.")
             return result
         else:
             raise ValidationError(result.get_messages_as_string())

--- a/python/src/aac/validate/_validate.py
+++ b/python/src/aac/validate/_validate.py
@@ -78,6 +78,9 @@ def _with_validation(
         result = _validate_definitions(user_definitions, language_context, validate_context)
 
         if result.is_valid():
+            print("The following file(s) have been validated:")
+            for definition in user_definitions:
+                print(definition.source.uri)
             return result
         else:
             raise ValidationError(result.get_messages_as_string())

--- a/python/tests/plugins/validators/test__validate_used_definitions.py
+++ b/python/tests/plugins/validators/test__validate_used_definitions.py
@@ -30,7 +30,7 @@ class TestValidateUsedDefinitions(ActiveContextTestCase):
             "UnreferencedSchema", fields=[]
         )
         invalid_reference_error_message = ""
-        
+
         test_findings = ValidatorFindings()
         expected_finding_location = SourceLocation(1, 8, 16, 18)
         lexeme = Lexeme(expected_finding_location, "", "")
@@ -38,13 +38,14 @@ class TestValidateUsedDefinitions(ActiveContextTestCase):
             test_unreferenced_schema_definition, invalid_reference_error_message, "validate thing", lexeme
         )
         expected_result = ValidatorResult([test_unreferenced_schema_definition], test_findings)
-        
+
         test_active_context = get_core_spec_context([test_unreferenced_schema_definition])
         field_definition = test_active_context.get_definition_by_name("Field")
-        
+
         actual_result = validate_used_definitions(test_unreferenced_schema_definition, field_definition, test_active_context, "type")
         actual_result_message = actual_result.get_messages_as_string()
-        
+
         self.assertEqual(expected_result.is_valid(), actual_result.is_valid())
         self.assertEqual(expected_finding_location, actual_result.findings.get_info_findings()[0].location.location)
+        self.assertIn("No references", actual_result_message)
         self.assertIn(test_unreferenced_schema_definition.name, actual_result_message)

--- a/python/tests/plugins/validators/test__validate_used_definitions.py
+++ b/python/tests/plugins/validators/test__validate_used_definitions.py
@@ -47,5 +47,4 @@ class TestValidateUsedDefinitions(ActiveContextTestCase):
         
         self.assertEqual(expected_result.is_valid(), actual_result.is_valid())
         self.assertEqual(expected_finding_location, actual_result.findings.get_info_findings()[0].location.location)
-        self.assertIn("No references", actual_result_message)
         self.assertIn(test_unreferenced_schema_definition.name, actual_result_message)

--- a/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
+++ b/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
@@ -16,7 +16,7 @@ suite("AaC Executable Wrapper Test Suite", () => {
                 const searchString = "0.3.";
                 assert.strictEqual(output.includes(searchString), true, `'${searchString}' not found in ${output}`);
             });
-    });
+    }).timeout(20000);
 
     test("it should execute the help command", async () => {
         const helpDumpCommand = {


### PR DESCRIPTION
# Description
Added listing definitions in which files that have been validated. 

# Linked Items:
Closes #571 

### Added
- When `_validate` makes a check for being valid, it prints out the definitions within files that have been validated. 

# Checklist:
- [x] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
