### PR TITLE
Corrected site links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Users who would like more detailed documentation on leveraging AaC can find it i
 We have a [Github Template Repository](https://github.com/Coffee2Bits/AaC-User-Template-Repository) that's setup to allow users exploring AaC to immediately create and experiment with an AaC project in their own GitHub repository. The created repository is pre-populated with a simple example model and Github Action workflow.
 
 ## Developer Documentation
-Contributors, developers, or just generally interested parties who would like to understand the more technical underpinnings of AaC are welcome to read the project and developer documentation found in our Github pages [Developer Guide Documentation](hhttps://arch-as-code.org/project_documentation/dev_guide/index.html)
+Contributors, developers, or just generally interested parties who would like to understand the more technical underpinnings of AaC are welcome to read the project and developer documentation found in our Github pages [Developer Guide Documentation](https://arch-as-code.org/project_documentation/dev_guide/index.html)
 
 ## Driving Value with AaC Plugins
 A simple example of one of the plugins mentioned above is the Plant UML plugin in the /plugins/aac-plantuml directory

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Main branch AaC Workflow](https://github.com/jondavid-black/AaC/actions/workflows/main-branch.yml/badge.svg)](https://github.com/jondavid-black/AaC/actions/workflows/main-branch.yml)
+[![Main branch AaC Workflow](https://github.com/DevOps-MBSE/AaC/actions/workflows/main-branch.yml/badge.svg)](https://github.com/DevOps-MBSE/AaC/actions/workflows/main-branch.yml)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 # Note to Contributors
@@ -157,13 +157,13 @@ available to use the AaC model to auto-generate content for reviews, documentati
 development and deployment.
 
 ## User Documentation
-Users who would like more detailed documentation on leveraging AaC can find it in our Github pages [User Guide Documentation](https://jondavid-black.github.io/AaC/project_documentation/user_guide/index.html)
+Users who would like more detailed documentation on leveraging AaC can find it in our Github pages [User Guide Documentation](https://arch-as-code.org/project_documentation/user_guide/index.html)
 
 ## Example AaC Template Repository
 We have a [Github Template Repository](https://github.com/Coffee2Bits/AaC-User-Template-Repository) that's setup to allow users exploring AaC to immediately create and experiment with an AaC project in their own GitHub repository. The created repository is pre-populated with a simple example model and Github Action workflow.
 
 ## Developer Documentation
-Contributors, developers, or just generally interested parties who would like to understand the more technical underpinnings of AaC are welcome to read the project and developer documentation found in our Github pages [Developer Guide Documentation](https://jondavid-black.github.io/AaC/project_documentation/dev_guide/index.html)
+Contributors, developers, or just generally interested parties who would like to understand the more technical underpinnings of AaC are welcome to read the project and developer documentation found in our Github pages [Developer Guide Documentation](hhttps://arch-as-code.org/project_documentation/dev_guide/index.html)
 
 ## Driving Value with AaC Plugins
 A simple example of one of the plugins mentioned above is the Plant UML plugin in the /plugins/aac-plantuml directory

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.3.15"
+__version__ = "0.3.16"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(


### PR DESCRIPTION
# Description

Corrected site links in README to point to new site domain. 

# Linked Items:

None

### Changed

- Site links in README to point to new site domain

# Checklist:

- [x] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
