### PR TITLE
Add the AaC Project Structure page

### DIFF
--- a/docs/source/project_documentation/dev_guide/index.rst
+++ b/docs/source/project_documentation/dev_guide/index.rst
@@ -6,6 +6,7 @@ Developer Guide Documentation
 
    Getting Started <dev_guide_index>
    Documentation <docs>
+   AaC Python Project Structure <project_structure>
    Plugin Developer Guide <plugin_dev_guide>
    AaC Validation <aac_validation>
    Validation Plugins for Developers <validation_plugins>

--- a/docs/source/project_documentation/dev_guide/index.rst
+++ b/docs/source/project_documentation/dev_guide/index.rst
@@ -6,7 +6,7 @@ Developer Guide Documentation
 
    Getting Started <dev_guide_index>
    Documentation <docs>
-   AaC Python Project Structure <project_structure>
+   Python Project Structure <project_structure>
    Plugin Developer Guide <plugin_dev_guide>
    AaC Validation <aac_validation>
    Validation Plugins for Developers <validation_plugins>

--- a/docs/source/project_documentation/dev_guide/project_structure.md
+++ b/docs/source/project_documentation/dev_guide/project_structure.md
@@ -2,10 +2,10 @@
 
 ## Python project
 
-The backbone of AaC is the python project which implements the underlying
+The backbone of AaC is the Python project which implements the underlying
 functionality for AaC, as a whole.
 
-### cli
+### `cli` Package
 
 Since AaC is built as a CLI-first tool in order to maintain a minimal footprint,
 enable integration into CI/CD pipelines, etc, we require functionality for
@@ -15,28 +15,27 @@ representation of AaC commands, translation between our internal structures and
 the [click][1] CLI framework which we use for CLI interaction, etc.
 
 Additionally, in the `cli.builtin_commands` package you will find AaC plugins
-that provide functionality without which AaC could not operate or could not
-operate effectively.
+that provide functionality without which AaC could not operate effectively.
 
-### io
+### `io` Package
 
 As the name suggests, the `io` package provides functionality related to I/O
 operations including parsing of AaC files.
 
-### lang
+### `lang` Package
 
 The `lang` package provides the main programmatic interface for interacting with
 AaC structures via the "Active Context" (which is an instance of a
 `LanguageContext`). It also provides various utilities to enable working with
 `Definition`s.
 
-### persistence
+### `persistence` Package
 
 At one point in time it was desirable to provide a level of persistence for the
 `ActiveContext` so the `persistence` package was created to handle that.
-Currently, however, it is unused and liable to be removed in a future version.
+Currently, however, it is being evaluated for deprecation in a future version since persistence is no longer meeting needs.
 
-### plugins
+### `plugins` Package
 
 At the heart of AaC's design philosophy is the desire to keep the core tool as
 minimal as possible and allow for enhancing AaC functionality via plugins. To
@@ -45,32 +44,32 @@ to allow AaC to be useful "out-of-the-box", we use the `plugins` package.
 
 The `plugins` package is similar to the `cli.builtin_commands` package except
 for the fact that every plugin in the `plugins.first_party` package and every
-validator in the `plugins.validators` (save for one - the `required_fields`
+validator in the `plugins.validators` (except for the `required_fields`
 validator) could be deployed separately from the core AaC and the tool would
 still work.
 
-### serialization
+### `serialization` Package
 
-We understand that not all AaC users will enjoy working from a terminal so we've
+We understand that not all AaC users will enjoy working from a terminal, so we've
 also built an AaC LSP server that enables users to work from an editor or IDE.
 To account for the need to run AaC commands from a non-CLI interface, we've
 provided JSON serialization for AaC commands and their arguments. The
 `serialization` package provides this functionality.
 
-### spec
+### `spec` Package
 
 The `spec` package provides utilities for loading and interacting with the core
 AaC specification. Additionally, the AaC DSL specification is defined in this
 package.
 
-### templates
+### `templates` Package
 
 Many AaC plugins generate output in some way. For anything more than simple
 output, we leverage the [Jinja2][2] templating engine. The plumbing for
 rendering templates and interacting with Jinja is contained in the `templates`
 package.
 
-### validate
+### `validate` Package
 
 A core feature of AaC is it's extensibility and flexibility. As a result, a
 plugin can contribute validations and the core AaC tool requires some way to

--- a/docs/source/project_documentation/dev_guide/project_structure.md
+++ b/docs/source/project_documentation/dev_guide/project_structure.md
@@ -71,9 +71,9 @@ package.
 
 ### `validate` Package
 
-A core feature of AaC is it's extensibility and flexibility. As a result, a
+A core feature of AaC is its extensibility and flexibility. As a result, a
 plugin can contribute validations and the core AaC tool requires some way to
-find and run them for a given definition. The `validate` package is responsible
+find them to execute against a given definition. The `validate` package is responsible
 for validator discovery and application.
 
 [1]: https://click.palletsprojects.com/en/

--- a/docs/source/project_documentation/dev_guide/project_structure.md
+++ b/docs/source/project_documentation/dev_guide/project_structure.md
@@ -1,0 +1,81 @@
+# Project Structure
+
+## Python project
+
+The backbone of AaC is the python project which implements the underlying
+functionality for AaC, as a whole.
+
+### cli
+
+Since AaC is built as a CLI-first tool in order to maintain a minimal footprint,
+enable integration into CI/CD pipelines, etc, we require functionality for
+allowing users to interact with the application via a command line. The `cli`
+package provides this functionality for users including an internal
+representation of AaC commands, translation between our internal structures and
+the [click][1] CLI framework which we use for CLI interaction, etc.
+
+Additionally, in the `cli.builtin_commands` package you will find AaC plugins
+that provide functionality without which AaC could not operate or could not
+operate effectively.
+
+### io
+
+As the name suggests, the `io` package provides functionality related to I/O
+operations including parsing of AaC files.
+
+### lang
+
+The `lang` package provides the main programmatic interface for interacting with
+AaC structures via the "Active Context" (which is an instance of a
+`LanguageContext`). It also provides various utilities to enable working with
+`Definition`s.
+
+### persistence
+
+At one point in time it was desirable to provide a level of persistence for the
+`ActiveContext` so the `persistence` package was created to handle that.
+Currently, however, it is unused and liable to be removed in a future version.
+
+### plugins
+
+At the heart of AaC's design philosophy is the desire to keep the core tool as
+minimal as possible and allow for enhancing AaC functionality via plugins. To
+balance this desire with the idea of providing enough additional functionality
+to allow AaC to be useful "out-of-the-box", we use the `plugins` package.
+
+The `plugins` package is similar to the `cli.builtin_commands` package except
+for the fact that every plugin in the `plugins.first_party` package and every
+validator in the `plugins.validators` (save for one - the `required_fields`
+validator) could be deployed separately from the core AaC and the tool would
+still work.
+
+### serialization
+
+We understand that not all AaC users will enjoy working from a terminal so we've
+also built an AaC LSP server that enables users to work from an editor or IDE.
+To account for the need to run AaC commands from a non-CLI interface, we've
+provided JSON serialization for AaC commands and their arguments. The
+`serialization` package provides this functionality.
+
+### spec
+
+The `spec` package provides utilities for loading and interacting with the core
+AaC specification. Additionally, the AaC DSL specification is defined in this
+package.
+
+### templates
+
+Many AaC plugins generate output in some way. For anything more than simple
+output, we leverage the [Jinja2][2] templating engine. The plumbing for
+rendering templates and interacting with Jinja is contained in the `templates`
+package.
+
+### validate
+
+A core feature of AaC is it's extensibility and flexibility. As a result, a
+plugin can contribute validations and the core AaC tool requires some way to
+find and run them for a given definition. The `validate` package is responsible
+for validator discovery and application.
+
+[1]: https://click.palletsprojects.com/en/
+[2]: https://jinja.palletsprojects.com/en/

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.3.17"
+__version__ = "0.3.18"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.3.18"
+__version__ = "0.3.19"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(


### PR DESCRIPTION
# Description

Added a project structure page in the documents that describes the overall structure of the AaC project.

# Linked Items:

Closes #471 

### Added

New page in documents called project_structure that describes the project directory structure.

# Checklist:

- [x] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
