### PR TITLE
added error raise when list field recieves a non list item.

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -138,7 +138,6 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult: 
                     if type(getattr(check_me, field.name)) != list:
                         raise LanguageError(
                             f"Value of '{field.name}' was expected to be list, but was '{type(getattr(check_me, field.name))}'. File: '{source_definition.source.uri}'",
-                            # source_definition.source.uri
                             None
                         )
                     for item in getattr(check_me, field.name):

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -39,7 +39,6 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult: 
         defining_primitive,
     ):
         """Runs all the constraints for a given primitive."""
-
         # Check the value_to_check against the defining_primitive
         defining_primitive_instance = defining_primitive
         for constraint_assignment in defining_primitive_instance.constraints:
@@ -75,7 +74,6 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult: 
         context = LanguageContext()
         if not context.is_aac_instance(check_against, "aac.lang.Schema"):
             return
-
         # collact applicable constraints
         schema_constraints = []
         for runner in context.get_plugin_runners():
@@ -134,8 +132,15 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult: 
 
             if field_definining_schema[0].get_root_key() == "primitive":
                 # if the field is a primitive, run the primitive constraints
+
                 if is_list:
                     # if the field is a list, check each item in the list
+                    if type(getattr(check_me, field.name)) != list:
+                        raise LanguageError(
+                            f"Value of '{field.name}' was expected to be list, but was '{type(getattr(check_me, field.name))}'. File: '{source_definition.source.uri}'",
+                            # source_definition.source.uri
+                            None
+                        )
                     for item in getattr(check_me, field.name):
                         value_to_check = item
                         if value_to_check is not None:

--- a/python/tests/test_aac/plugins/check/bad.aac
+++ b/python/tests/test_aac/plugins/check/bad.aac
@@ -1,0 +1,4 @@
+req_spec:
+  name: "req4_2_2"
+  description: "MSPSP Preparation. Requirements for preparing an MSPSP can be found in Attachment 2 of this volume. SSCMAN91_710_3 27 DECEMBER 2_22_13"
+  parent_specs: "SSCMAN91_710_3_27_DECEMBER_2_22_13"

--- a/python/tests/test_aac/plugins/check/test_checkaac.py
+++ b/python/tests/test_aac/plugins/check/test_checkaac.py
@@ -49,7 +49,6 @@ class TestCheckAaC(TestCase):
             shutil.copy(aac_file_path, temp_aac_file_path)
 
             check_args = [temp_aac_file_path]
-            # with self.assertRaises(LanguageError) as e:
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
             self.assertNotEqual(0, exit_code)
             self.assertIn("was expected to be list, but was", output_message)

--- a/python/tests/test_aac/plugins/check/test_checkaac.py
+++ b/python/tests/test_aac/plugins/check/test_checkaac.py
@@ -3,6 +3,7 @@ from typing import Tuple
 from click.testing import CliRunner
 from aac.execute.command_line import cli, initialize_cli
 from aac.execute.aac_execution_result import ExecutionStatus
+from aac.context.language_error import LanguageError
 
 import os
 import shutil
@@ -39,3 +40,16 @@ class TestCheckAaC(TestCase):
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
 
             self.assertEqual(0, exit_code, f"Expected success but failed with message: {output_message}")  # asserts the command ran successfully
+
+    def test_cli_check_bad_data(self):
+        """Test the CLI command for the check plugin."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            aac_file_path = os.path.join(os.path.dirname(__file__), "bad.aac")
+            temp_aac_file_path = os.path.join(temp_dir, "my_plugin.aac")
+            shutil.copy(aac_file_path, temp_aac_file_path)
+
+            check_args = [temp_aac_file_path]
+            # with self.assertRaises(LanguageError) as e:
+            exit_code, output_message = self.run_check_cli_command_with_args(check_args)
+            self.assertNotEqual(0, exit_code)
+            self.assertIn("was expected to be list, but was", output_message)


### PR DESCRIPTION
# Description

Includes a language error raise when a non-list is given to a command that expects a list.

# Linked Items:

Closes/Fixes/Resolves [#769](https://github.com/DevOps-MBSE/AaC/issues/769) 
Closes #790 

### Added

- _Language error raise when list type is expected but non-list is given.

### Changed

- _Describe any changes in existing functionality._

### Deprecated

- _Describe any deprecated features._

### Removed

- _Describe any removed features._

### Fixed

- _Describe any bug fixes._

### Security

- _Describe any security-related changes._

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [ ] I added the labels corresponding to my changes.
