### PR TITLE
Adding Standalone Plugin Registration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils>=0.19
 furo~=2024.5.6
 myst-parser>=2.0.0
-sphinx>=6.1.3
+sphinx>=7.3.7
 sphinx-contributors>=0.2.7
 sphinx-copybutton>=0.5.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils>=0.19
 furo~=2024.5.6
 myst-parser>=2.0.0
-sphinx>=7.3.7
+sphinx>=6.1.3
 sphinx-contributors>=0.2.7
 sphinx-copybutton>=0.5.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils>=0.19
-furo>=2023.05.20
+furo~=2024.5.6
 myst-parser>=2.0.0
-sphinx>=6.1.3
+sphinx>=7.3.7
 sphinx-contributors>=0.2.7
 sphinx-copybutton>=0.5.2

--- a/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
+++ b/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
@@ -87,26 +87,19 @@ Options:
 While the `gen-plugin` command will attempt to sort out directory paths for you if not provided, it's often simplest to just provide `--code-output` and `--test-output` to ensure the generated code is placed where you want it.  Currently the `gen-plugin` command does not output documentation, but the functionality is currently under development. The `--doc-output` will create plugin documentation outlines that mirror current plugin documentation pages as seen in the [Plugins Guide](../plugins/plugins_index.md).
 
 #### Standalone Plugins
+
 If you are creating plugins external to the core AaC tool to provide additional functionality, commands, and/or constraints for your team's use, then there are some additional infrastructure changes that one must, currently, manually implement until we have been able to update both the `gen-project` and `gen-plugin` commands to make the appropriate changes for supporting standalone plugins utilizing the more recent build chain implementation.
 
 These changes include manually updating the currently generated `setup.py` to have the `entry_points` include the new plugin. Or, if manually implementing a `pyproject.toml` file to use the updated Python standard, ensure the `[project.entry-points."aac"]` is configured to include the new plugin. And ensure you set the package discovery of your project file.
 
-*pyproject.toml entry*
-```pyproject.toml
+##### `pyproject.toml` Configurations
+```python
 [project.entry-points."aac"]
 rest-api = "rest_api"
 
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["tests"]
-```
-*setup.py entry*
-```setup.py
-entry_points={
-    "aac": ["eval-req=aac_req_qa"],
-},
-
-packages=find_packages(where="src")
 ```
 
 If you are using the `pyproject.toml` file, a `MANIFEST.in` will have to be included with the following content:
@@ -122,6 +115,16 @@ And you will have to add the following lines to your `tox.ini` under the `[tox]`
 ```
 isolated_build = True
 skipsdist = True
+```
+
+##### `setup.py` Configurations
+
+```python
+entry_points={
+    "aac": ["eval-req=aac_req_qa"],
+},
+
+packages=find_packages(where="src")
 ```
 
 #### Input of Gen-Plugin

--- a/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
+++ b/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
@@ -43,7 +43,7 @@ Options:
                      impact to existing files.
   -h, --help         Show this message and exit.
 ```
-*Note:  AaC generation attempts to be non-distructive.  Each generation template definition recognized what output should be fully generated and what may be user modified.  If any file is being generated where an existing file already exists, the generator will create a backup of the original prior to writing the new file.  If a user modifiable file is to be generated but already exists, the new file will be created as an evaluation file for the user to consider without impacting the existing file.  Generator commends can adjust this behavior using `--force-overwrite` and `--evaluate` flags.*
+*Note:  AaC generation attempts to be non-destructive.  Each generation template definition recognized what output should be fully generated and what may be user modified.  If any file is being generated where an existing file already exists, the generator will create a backup of the original prior to writing the new file.  If a user modifiable file is to be generated but already exists, the new file will be created as an evaluation file for the user to consider without impacting the existing file.  Generator commends can adjust this behavior using `--force-overwrite` and `--evaluate` flags.*
 
 This will create a project structure that looks like this:
 
@@ -55,6 +55,8 @@ This will create a project structure that looks like this:
 ├── tests
 └── tox.ini
 ```
+
+*Note: AaC is in the process of updating its build chain to utilize the new preferred Python project file, `pyproject.toml`, to handle the project configuration and declaration. The `gen-project` command will be updated to produce this file and other necessary project infrastructure changes. For more information on this, view the [Standalone Plugin documentation](#standalone-plugins).*
 
 ## Generating AaC Plugins (Gen-Plugin Command)
 
@@ -82,7 +84,35 @@ Options:
   -h, --help          Show this message and exit.
 ```
 
-While the `gen-plugin` command will attempt to sort out directory paths for you if not provided, it's often simplest to just provide `--code-output` and `--test-output` to ensure the generated code is placed where you want it.  Currently the `gen-plugin` command doesn't output documentation, but the option is in place for future use.
+While the `gen-plugin` command will attempt to sort out directory paths for you if not provided, it's often simplest to just provide `--code-output` and `--test-output` to ensure the generated code is placed where you want it.  Currently the `gen-plugin` command does not output documentation, but the functionality is currently under development. The `--doc-output` will create plugin documentation outlines that mirror current plugin documentation pages as seen in the [Plugins Guide](../plugins/plugins_index.md).
+
+#### Standalone Plugins
+If you are creating plugins external to the core Aac tool to provide additional functionality, commands, and constraints for your team's use, then there are some additional infrastructure changes that one must, currently, manually implement until we have been able to update both the `gen-project` and `gen-plugin` commands to make the appropriate changes for supporting standalone plugins utilizing the more recent build chain implementation.
+
+These changes include manually updating the currently generated `setup.py` to have the `entry_points` include the new plugin. Or, if manually implementing a `pyproject.toml` file to use the updated Python standard, ensure the `[project.entry-points."aac"]` is configured to include the new plugin. And ensure you set the package discovery of your project file.
+```pyproject.toml
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["tests"]
+```
+```setup.py
+packages=find_packages(where="src")
+```
+
+If you are using the `pyproject.toml` file, a `MANIFEST.in` will have to be included with the following content:
+```
+graft src
+graft tests
+
+include tox.ini
+include src/rest-api/rest_api.aac
+```
+
+And you will have to add the following lines to your `tox.ini` under the `[tox]` section:
+```
+isolated_build = True
+skipsdist = True
+```
 
 #### Input of Gen-Plugin
 
@@ -119,7 +149,7 @@ The output of the `gen-plugin` command will be some corresponding plugin files t
 
 The generated files are:
 
-```markdown
+```console
 └── src
 |   └── aac_example
 |       └── plugins

--- a/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
+++ b/docs/source/project_documentation/dev_guide/plugin_dev_guide.md
@@ -43,7 +43,7 @@ Options:
                      impact to existing files.
   -h, --help         Show this message and exit.
 ```
-*Note:  AaC generation attempts to be non-destructive.  Each generation template definition recognized what output should be fully generated and what may be user modified.  If any file is being generated where an existing file already exists, the generator will create a backup of the original prior to writing the new file.  If a user modifiable file is to be generated but already exists, the new file will be created as an evaluation file for the user to consider without impacting the existing file.  Generator commends can adjust this behavior using `--force-overwrite` and `--evaluate` flags.*
+*Note:  AaC generation attempts to be non-destructive.  Each generation template definition recognizes what output should be fully generated and what may be user modified.  If any file is being generated where an existing file already exists, the generator will create a backup of the original prior to writing the new file.  If a user modifiable file is to be generated but already exists, the new file will be created as an evaluation file for the user to consider without impacting the existing file.  Generator commands can adjust this behavior using `--force-overwrite` and `--evaluate` flags.*
 
 This will create a project structure that looks like this:
 
@@ -87,15 +87,25 @@ Options:
 While the `gen-plugin` command will attempt to sort out directory paths for you if not provided, it's often simplest to just provide `--code-output` and `--test-output` to ensure the generated code is placed where you want it.  Currently the `gen-plugin` command does not output documentation, but the functionality is currently under development. The `--doc-output` will create plugin documentation outlines that mirror current plugin documentation pages as seen in the [Plugins Guide](../plugins/plugins_index.md).
 
 #### Standalone Plugins
-If you are creating plugins external to the core Aac tool to provide additional functionality, commands, and constraints for your team's use, then there are some additional infrastructure changes that one must, currently, manually implement until we have been able to update both the `gen-project` and `gen-plugin` commands to make the appropriate changes for supporting standalone plugins utilizing the more recent build chain implementation.
+If you are creating plugins external to the core AaC tool to provide additional functionality, commands, and/or constraints for your team's use, then there are some additional infrastructure changes that one must, currently, manually implement until we have been able to update both the `gen-project` and `gen-plugin` commands to make the appropriate changes for supporting standalone plugins utilizing the more recent build chain implementation.
 
 These changes include manually updating the currently generated `setup.py` to have the `entry_points` include the new plugin. Or, if manually implementing a `pyproject.toml` file to use the updated Python standard, ensure the `[project.entry-points."aac"]` is configured to include the new plugin. And ensure you set the package discovery of your project file.
+
+*pyproject.toml entry*
 ```pyproject.toml
+[project.entry-points."aac"]
+rest-api = "rest_api"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["tests"]
 ```
+*setup.py entry*
 ```setup.py
+entry_points={
+    "aac": ["eval-req=aac_req_qa"],
+},
+
 packages=find_packages(where="src")
 ```
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,7 +55,7 @@ development_dependencies = [
 ]
 
 documentation_dependencies = [
-    "sphinx >= 6.1.3",
+    "sphinx >= 7.3.7",
     "sphinxcontrib-applehelp ~= 1.0.2",
     "sphinxcontrib-devhelp ~= 1.0.2",
     "sphinxcontrib-htmlhelp ~= 2.0.0",
@@ -66,7 +66,7 @@ documentation_dependencies = [
     "sphinx_contributors ~= 0.2.7",
     "sphinx-autobuild ~= 2021.3.14",
     "sphinx-simplepdf ~= 1.6.0",
-    "furo ~= 2023.7.26",
+    "furo ~= 2024.5.6",
     "docutils ~= 0.19",
     "myst-parser ~= 2.0.0",
     "pytz ~= 2023.3"

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,7 +55,7 @@ development_dependencies = [
 ]
 
 documentation_dependencies = [
-    "sphinx >= 7.3.7",
+    "sphinx >= 6.1.3",
     "sphinxcontrib-applehelp ~= 1.0.2",
     "sphinxcontrib-devhelp ~= 1.0.2",
     "sphinxcontrib-htmlhelp ~= 2.0.0",

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ runtime_dependencies = [
 development_dependencies = [
     "wheel ~= 0.42.0",
     "pip-tools >= 6.9.0",
-    "tomli < 2.0.0",
+    "tomli >= 2.0.1; python_version < '3.11'",
     "platformdirs >= 2.4",
     "coverage >= 6.0",
     "mccabe >= 0.6.1",
@@ -55,7 +55,7 @@ development_dependencies = [
 ]
 
 documentation_dependencies = [
-    "sphinx >= 6.1.3",
+    "sphinx >= 7.3.7",
     "sphinxcontrib-applehelp ~= 1.0.2",
     "sphinxcontrib-devhelp ~= 1.0.2",
     "sphinxcontrib-htmlhelp ~= 2.0.0",

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(


### PR DESCRIPTION
# Description

Included information for generating a standalone plugin and having it be detected by core AaC.

# Linked Items:

Closes/Fixes/Resolves #806 

### Added
- Standalone plugin registration information.
- Some additional notes around generation for some upcoming changes.

### Changed
- Corrected some misspellings and phrasings.
- 
# Checklist:

- [x] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
