### PR TITLE
added change to flag when def is loaded and removed

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.4.18"
+__version__ = "0.4.19"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -824,11 +824,11 @@ class DefinitionParser():
         for definition in self.parsed_definitions:
             # create and register the instance
             self.create_definition_instance(definition)
+            definition.source.is_loaded_in_context = True
             result.append(definition)
             self.context.context_instance.definitions.add(definition)
             self.context.context_instance.fully_qualified_name_to_definition[
                 f"{definition.package}.{definition.name}"
             ] = definition
-            definition.source.is_loaded_in_context = True
 
         return result

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -829,5 +829,6 @@ class DefinitionParser():
             self.context.context_instance.fully_qualified_name_to_definition[
                 f"{definition.package}.{definition.name}"
             ] = definition
+            definition.source.is_loaded_in_context = True
 
         return result

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -114,8 +114,8 @@ class LanguageContext(object):
     def remove_definitions(self, definitions: list[Definition]) -> None:
         """Remove the given definitions from the context."""
         for definition in definitions:
-            self.context_instance.definitions.remove(definition)
             definition.source.is_loaded_in_context = False
+            self.context_instance.definitions.remove(definition)
             del self.context_instance.fully_qualified_name_to_definition[
                 f"{definition.package}.{definition.name}"
             ]

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -115,6 +115,7 @@ class LanguageContext(object):
         """Remove the given definitions from the context."""
         for definition in definitions:
             self.context_instance.definitions.remove(definition)
+            definition.source.is_loaded_in_context = False
             del self.context_instance.fully_qualified_name_to_definition[
                 f"{definition.package}.{definition.name}"
             ]

--- a/python/tests/test_aac/context/test_definition_parser.py
+++ b/python/tests/test_aac/context/test_definition_parser.py
@@ -18,6 +18,7 @@ class TestDefinitionParser(TestCase):
         self.assertEqual(len(context_definitions), 1)
         self.assertEqual(loaded_definitions, context_definitions)
         self.assertEqual(len(context_definitions[0].instance.fields), len(loaded_definitions[0].instance.fields))
+        self.assertTrue(loaded_definitions[0].source.is_loaded_in_context)
 
     def test_load_definitions_fail(self):
         parser = DefinitionParser()

--- a/python/tests/test_aac/context/test_definition_parser.py
+++ b/python/tests/test_aac/context/test_definition_parser.py
@@ -26,6 +26,7 @@ class TestDefinitionParser(TestCase):
         with self.assertRaises(ParserError) as e:
             definitions = parse(INVALID_AAC_YAML_CONTENT)
             loaded_definitions = parser.load_definitions(context=context, parsed_definitions=definitions)
+            self.assertFalse(definitions[0].source.is_loaded_in_context)
 
 VALID_AAC_YAML_CONTENT = """
 schema:


### PR DESCRIPTION
# Description

is_loaded_in_context attribute is now updated when a definition is loaded and removed from the context

# Linked Items:

Closes/Fixes/Resolves #830 

### Added

- _Describe any new features._

### Changed

- _Describe any changes in existing functionality._

### Deprecated

- _Describe any deprecated features._

### Removed

- _Describe any removed features._

### Fixed

Fixed a bug where is_loaded_in_context was not being updated correctly.

### Security

- _Describe any security-related changes._

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
