### PR TITLE
Fixing a bug where the context could not find definition names with spaces when searched for.

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 
-__version__ = "0.4.19"
+__version__ = "0.4.20"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -131,7 +131,7 @@ class LanguageContext(object):
         if "." not in name:
             search_name = f".{name}"
         for definition in self.get_definitions():
-            if definition.get_fully_qualified_name().endswith(search_name):
+            if definition.get_fully_qualified_name().endswith(search_name.replace(" ", "")):
                 result.append(definition)
         return result
 

--- a/python/tests/test_aac/context/test_language_context.py
+++ b/python/tests/test_aac/context/test_language_context.py
@@ -24,7 +24,7 @@ class TestLanguageContext(TestCase):
         definitions = context.parse_and_load(VALID_AAC_YAML_CONTENT)
         self.assertEqual(len(definitions), 1)
         self.assertIsNotNone(definitions[0].instance)
-        self.assertEqual(definitions[0].name, "TestSchema")
+        self.assertEqual(definitions[0].name, "Test Schema")
         self.assertEqual(len(definitions[0].instance.fields), 4)
 
     def test_get_definitions(self):
@@ -43,6 +43,9 @@ class TestLanguageContext(TestCase):
         self.assertEqual(len(definitions), 1)
         self.assertEqual(definitions[0].name, "Schema")
         self.assertIsNotNone(definitions[0].instance)
+
+        context.parse_and_load(VALID_AAC_YAML_CONTENT)
+        definitions = context.definitions = context.get_definitions_by_name("Test Schema")
 
     def test_get_definitions_by_root(self):
         context = LanguageContext()
@@ -105,7 +108,7 @@ class TestLanguageContext(TestCase):
 
 VALID_AAC_YAML_CONTENT = """
 schema:
-  name: TestSchema
+  name: Test Schema
   description: |
     This is a test schema.
   fields:

--- a/python/tests/test_aac/context/test_language_context.py
+++ b/python/tests/test_aac/context/test_language_context.py
@@ -24,7 +24,7 @@ class TestLanguageContext(TestCase):
         definitions = context.parse_and_load(VALID_AAC_YAML_CONTENT)
         self.assertEqual(len(definitions), 1)
         self.assertIsNotNone(definitions[0].instance)
-        self.assertEqual(definitions[0].name, "Test Schema")
+        self.assertEqual(definitions[0].name, "TestSchema")
         self.assertEqual(len(definitions[0].instance.fields), 4)
 
     def test_get_definitions(self):
@@ -44,8 +44,9 @@ class TestLanguageContext(TestCase):
         self.assertEqual(definitions[0].name, "Schema")
         self.assertIsNotNone(definitions[0].instance)
 
-        context.parse_and_load(VALID_AAC_YAML_CONTENT)
-        definitions = context.definitions = context.get_definitions_by_name("Test Schema")
+        context.parse_and_load(VALID_AAC_YAML_CONTENT_SPACE_IN_NAME)
+        definitions = context.get_definitions_by_name("Test Schema")
+        self.assertEqual(definitions[0].name, "TestSchema")
 
     def test_get_definitions_by_root(self):
         context = LanguageContext()
@@ -107,6 +108,30 @@ class TestLanguageContext(TestCase):
             self.assertGreater(len(values), 1)
 
 VALID_AAC_YAML_CONTENT = """
+schema:
+  name: TestSchema
+  description: |
+    This is a test schema.
+  fields:
+    - name: string_field
+      type: string
+      description: |
+        This is a test field.
+    - name: integer_field
+      type: integer
+      description: |
+        This is a test field.
+    - name: boolean_field
+      type: boolean
+      description: |
+        This is a test field.
+    - name: number_field
+      type: number
+      description: |
+        This is a test field.
+""".strip()
+
+VALID_AAC_YAML_CONTENT_SPACE_IN_NAME = """
 schema:
   name: Test Schema
   description: |

--- a/python/tests/test_aac/context/test_language_context.py
+++ b/python/tests/test_aac/context/test_language_context.py
@@ -46,7 +46,7 @@ class TestLanguageContext(TestCase):
 
         context.parse_and_load(VALID_AAC_YAML_CONTENT_SPACE_IN_NAME)
         definitions = context.get_definitions_by_name("Test Schema")
-        self.assertEqual(definitions[0].name, "TestSchema")
+        self.assertEqual(definitions[0].name, "Test Schema")
 
     def test_get_definitions_by_root(self):
         context = LanguageContext()


### PR DESCRIPTION


# Description

The language context could not find definitions with spaces in their name because the fully qualified names are converted to python class names, which cannot have spaces.  It seems to automatically remove the spaces from the python class name, so I had the search also remove the spaces from the name being searched for.

# Linked Items:

Closes/Fixes/Resolves #828 

### Added

- _Describe any new features._

### Changed

- _Describe any changes in existing functionality._

### Deprecated

- _Describe any deprecated features._

### Removed

- _Describe any removed features._

### Fixed

get_definitions_by_name can now search for and find definitions with spaces in its name.

### Security

- _Describe any security-related changes._

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [ ] I added the labels corresponding to my changes.
