### PR TITLE
Fix Exception Missing Location Param (#881)

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.4.30"
+__version__ = "0.4.31"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -530,7 +530,10 @@ class DefinitionParser():
             instance = []
             if not field_value:
                 if is_required:
-                    raise LanguageError(f"Missing required field {field_name}")
+                    raise LanguageError(
+                        message=f"Missing required field {field_name}",
+                        location=None
+                    )
             else:
                 if not isinstance(field_value, list):
                     if is_required:


### PR DESCRIPTION
# Description

Quick fix for a missing required parameter in the LanguageException constructor.

# Linked Items:

Closes/Fixes/Resolves #881

### Added

- None

### Changed

- None

### Deprecated

- None

### Removed

- None

### Fixed

- Missing location parameter in LanguageException constructor call.

### Security

- None

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [ ] I added the labels corresponding to my changes.
