### PR TITLE
LanguageError/Lexeme work in definition_parser to prevent "None" locations.

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -546,7 +546,7 @@ class DefinitionParser():
                 if is_required:
                     raise LanguageError(
                         message=f"Missing required field {field_name}",
-                        location=get_location_str(definition.name, lexemes)
+                        location=self.get_location_str(definition.name, lexemes)
                     )
             else:
                 if not isinstance(field_value, list):
@@ -598,7 +598,7 @@ class DefinitionParser():
         python_type = defining_definition.structure["primitive"]["python_type"]
         if not field_value:
             if is_required:
-                raise LanguageError(message=f"Missing required field {field_name}.", location=get_location_str(definition.name, lexemes))
+                raise LanguageError(message=f"Missing required field {field_name}.", location=self.get_location_str(definition.name, lexemes))
             if is_list:
                 field_value = []
         elif is_list:

--- a/python/tests/test_aac/context/test_definition_parser.py
+++ b/python/tests/test_aac/context/test_definition_parser.py
@@ -40,6 +40,22 @@ class TestDefinitionParser(TestCase):
             loaded_definitions = parser.load_definitions(context=context, parsed_definitions=definitions)  # noqa: F841
             self.assertFalse(definitions[0].source.is_loaded_in_context)
 
+    def test_load_incomplete_definition(self):
+        parser = DefinitionParser()
+        context = LanguageContext()
+        with self.assertRaises(ParserError):
+            definitions = parse(SCHEMA_WITH_INCOMPLETE_FIELD)
+            loaded_definitions = parser.load_definitions(context=context, parsed_definitions=definitions)  # noqa: F841
+            self.assertFalse(definitions[0].source.is_loaded_in_context)
+
+    def test_load_bad_enum(self):
+        parser = DefinitionParser()
+        context = LanguageContext()
+        with self.assertRaises(ParserError):
+            definitions = parse(SCHEMA_WITH_BAD_ENUM)
+            loaded_definitions = parser.load_definitions(context=context, parsed_definitions=definitions)  # noqa: F841
+            self.assertFalse(definitions[0].source.is_loaded_in_context)
+
 
 VALID_AAC_YAML_CONTENT = """
 schema:
@@ -89,7 +105,6 @@ schema:
         This is a test field.
 """.strip()
 
-
 INVALID_AAC_YAML_CONTENT = """
 schema:
   description: |
@@ -112,3 +127,56 @@ schema:
       description: |
         This is a test field.
 """.strip()
+
+SCHEMA_WITH_INCOMPLETE_FIELD = """
+schema:
+  description: |
+    This is a test schema.
+  fields:
+    - name: string_field
+      type: string
+      description: |
+        This is a test field.
+    - name: integer_field
+      type: integer
+      description: |
+        This is a test field.
+    - name: boolean_field
+      type: boolean
+      description: |
+        This is a test field.
+    - name: number_field
+      type: number
+      description: |
+        This is a test field.
+    - name: not_used
+""".strip()
+
+SCHEMA_WITH_BAD_ENUM= """
+schema:
+  description: |
+    This is a test schema.
+  fields:
+    - name: string_field
+      type: string
+      description: |
+        This is a test field.
+    - name: integer_field
+      type: integer
+      description: |
+        This is a test field.
+    - name: boolean_field
+      type: boolean
+      description: |
+        This is a test field.
+    - name: number_field
+      type: number
+      description: |
+        This is a test field.
+   enum:
+    name: bad_enum
+    values:
+        - bad_value
+        - bad_value
+""".strip()
+


### PR DESCRIPTION
# Description

LanguageError/Lexeme work in definition_parser to prevent "None" locations. Previously there were two instances where LanguageErrors were being created with an explicit location of "None".

# Linked Items:

Works toward closing https://github.com/DevOps-MBSE/AaC/issues/919

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [ ] I added the labels corresponding to my changes.
