### PR TITLE
Pip upgrade steps

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,7 @@ tasks:
       cd python/
       python3.9 -m venv venv --system-site-packages
       source venv/bin/activate
+      python -m pip install --upgrade pip
       pip install -e .[all]
     command: cd /workspace/AaC/python/; source venv/bin/activate # Always launch a console with our virtual env
 

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 


### PR DESCRIPTION
# Description

Ensure .gitpod.yml pip upgrade and pip install steps are identical across various AaC repositories. The only repository needing update was AaC.

# Linked Items:

Closes (https://github.com/DevOps-MBSE/AaC/issues/896)

### Added

- Updated .gitpod.yml with pip upgrade step

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
