### PR TITLE
Adccs 2385 plugin documentation no arguments

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/plugins/gen_plugin/templates/plugin_documentation.jinja2
+++ b/python/src/aac/plugins/gen_plugin/templates/plugin_documentation.jinja2
@@ -22,13 +22,16 @@
 {%- endif %}
     {{input.name}} {{"("}}{{input.type}}{{")"}}
         {{ input.description -}}
-
 {%- endif -%}
 {%- endfor -%}
-{% if optionals[0] is defined %} {# Check that this is defined before popping. This covers cases with no Optional Arguments #}
-{% set temp = optionals.pop(0) %} {# Pop the optional arguments flag so we can be ready for the next command if there is one #}
+{%- if optionals[0] is defined -%} {# Check that this is defined before popping. This covers cases with no Optional Arguments #}
+{%- set temp = optionals.pop(0) -%} {# Pop the optional arguments flag so we can be ready for the next command if there is one #}
 {%- endif -%}
-{% endif %}
+{% else %} {# account for plugins with no arguments #}
+### Arguments
+    There are no arguments for the {{ command.name }} command
+{%- endif %}
+
 {{"<Insert command screenshot here>"}}
 {% endfor %}
 {%- endif %}

--- a/python/tests/test_aac/plugins/gen_plugin/gen_plugin_optional_args.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/gen_plugin_optional_args.aac
@@ -1,0 +1,63 @@
+plugin:
+  name: Gen Plugin
+  package: aac.plugins.gen_plugin
+  description: |
+    An AaC plugin that generates opinionated plugin stubs for easier
+    and quicker plugin development.
+  commands:
+    - name: gen-plugin
+      help_text: |
+        Generate code and stubs for an AaC plugin.  Overwrites will backup existing files.
+      run_before:
+        - plugin: Check AaC
+          command: check
+      run_after:
+        - plugin: Generate
+          command: generate
+      input:
+        - name: aac-plugin-file
+          type: file
+          description: The path to the architecture file with the plugin definition.
+        - name: --code-output
+          type: directory
+          description: The location to output generated plugin code.
+        - name: --test-output
+          type: directory
+          description: The location to output generated plugin test code.
+        - name: --doc-output
+          type: directory
+          description: The location to output generated plugin documentation code.
+        - name: --no-prompt
+          type: bool
+          description: Instructs the generator to execute without asking the user to confirm output paths.
+        - name: --force-overwrite
+          type: bool
+          description: Instructs the generator to backup and overwrite all existing files regardless of template definition.
+        - name: --evaluate
+          type: bool
+          description: Instructs the generator to only write evaluation files with no impact to existing files.
+    - name: gen-project
+      help_text: |
+        Generate code and stubs for an AaC project.  Overwrites will backup existing files.
+      run_before:
+        - plugin: Check AaC
+          command: check
+      run_after:
+        - plugin: Generate
+          command: generate
+      input:
+        - name: aac-project-file
+          type: file
+          description: The path to the architecture file with the project definition.
+        - name: --output
+          type: directory
+          description: The location to output generated project code.
+        - name: --no-prompt
+          type: bool
+          description: Instructs the generator to execute without asking the user to confirm output paths.
+        - name: --force-overwrite
+          type: bool
+          description: Instructs the generator to backup and overwrite all existing files regardless of template definition.
+        - name: --evaluate
+          type: bool
+          description: Instructs the generator to only write evaluation files with no impact to existing files.

--- a/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
+++ b/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
@@ -346,3 +346,60 @@ class TestGenPlugin(TestCase):
             exit_code, output_message = self.run_gen_project_cli_command_with_args(proj_args)
             self.assertNotEqual(0, exit_code)
             self.assertIn("Definition is missing field 'name'", output_message)
+
+    # There is a special case where documentation needs to be generated for optional arguments
+    # This tests for that special case and the expected hard-coded header of "Optional Arguments"
+    # The other tests in this file account for the nominal cases
+    def test_cli_gen_plugin_optional_args_documentation(self):
+        # first we need a project to work in, so generate a temporary one
+        with TemporaryDirectory() as temp_dir:
+            # now create an AaC plugin file in the project src directory
+            aac_file_path = path.join(path.dirname(__file__), "gen_plugin_optional_args.aac")
+            temp_aac_file_path = path.join(temp_dir, "gen_plugin_optional_args.aac")
+            copy(aac_file_path, temp_aac_file_path)
+
+            proj_args = [temp_aac_file_path, "--output", temp_dir, "--no-prompt"]
+            exit_code, output_message = self.run_gen_project_cli_command_with_args(proj_args)
+
+            package_src_path = path.join(temp_dir, "src", "happy")
+            mkdir(package_src_path)
+            package_doc_path = path.join(temp_dir, "docs")
+            plugin_file_path = path.join(package_src_path, "gen_plugin_optional_args.aac")
+
+            aac_plugin_path = path.join(path.dirname(__file__), "gen_plugin_optional_args.aac")
+            copy(aac_plugin_path, plugin_file_path)
+            plugin_args = [plugin_file_path, "--code-output", path.join(temp_dir, "src"), "--test-output", path.join(temp_dir, "tests"), "--doc-output", package_doc_path, "--no-prompt"]
+            exit_code, output_message = self.run_gen_plugin_cli_command_with_args(plugin_args)
+            file = open(path.join(package_doc_path, "gen_plugin.md"), "r")
+            file_read = file.read()
+            self.assertIn("Optional Arguments", file_read) # Optional header to test for
+            self.assertIn("--doc-output", file_read) # Optional argument from gen_plugin_optional_args.aac
+            file.close()
+
+    # There is a special case where documentation needs to be generated but the plugin has no arguments
+    # This tests for that special case and the expected hard-coded language of "There are no arguments for the..."
+    # The other tests in this file account for the nominal cases
+    def test_cli_gen_plugin_no_args_documentation(self):
+        # first we need a project to work in, so generate a temporary one
+        with TemporaryDirectory() as temp_dir:
+            # now create an AaC plugin file in the project src directory
+            aac_file_path = path.join(path.dirname(__file__), "version_no_args.aac")
+            temp_aac_file_path = path.join(temp_dir, "version_no_args.aac")
+            copy(aac_file_path, temp_aac_file_path)
+
+            proj_args = [temp_aac_file_path, "--output", temp_dir, "--no-prompt"]
+            exit_code, output_message = self.run_gen_project_cli_command_with_args(proj_args)
+
+            package_src_path = path.join(temp_dir, "src", "happy")
+            mkdir(package_src_path)
+            package_doc_path = path.join(temp_dir, "docs")
+            plugin_file_path = path.join(package_src_path, "version_no_args.aac")
+
+            aac_plugin_path = path.join(path.dirname(__file__), "version_no_args.aac")
+            copy(aac_plugin_path, plugin_file_path)
+            plugin_args = [plugin_file_path, "--code-output", path.join(temp_dir, "src"), "--test-output", path.join(temp_dir, "tests"), "--doc-output", package_doc_path, "--no-prompt"]
+            exit_code, output_message = self.run_gen_plugin_cli_command_with_args(plugin_args)
+            file = open(path.join(package_doc_path, "version.md"), "r")
+            file_read = file.read()
+            self.assertIn("There are no arguments for the", file_read)
+            file.close()

--- a/python/tests/test_aac/plugins/gen_plugin/version_no_args.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/version_no_args.aac
@@ -1,0 +1,7 @@
+plugin:
+  name: Version
+  package: aac.plugins.version
+  description: An AaC plugin that outputs the Architecture-as-Code Python package version.
+  commands:
+    - name: version
+      help_text: Print the AaC package version.


### PR DESCRIPTION
# Description

Updated plugin_documentation.jinja2 to account for a no-arguments possibility and in that case print out a canned line of text stating as such
Added unit tests inputs and unit tests for both the 1) no arguments, and 2) optional arguments cases.

# Linked Items:

Closes <https://github.com/DevOps-MBSE/AaC/issues/929>

### Added

Updated plugin_documentation.jinja2 to account for a no-arguments possibility and in that case print out a canned line of text stating as such
Added unit tests inputs and unit tests for both the 1) no arguments, and 2) optional arguments cases.

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
