### PR TITLE
Context constraint error handling

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.16"
+__version__ = "0.5.19"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -416,7 +416,7 @@ def _collect_all_constraints_by_name() -> dict[str, Callable]:
 
 def find_definitions_to_check(aac_file: str) -> (list[Definition], ExecutionStatus):
     """
-    Lower level helper method to call collect the definitions to check by calling parse_and_load and handling any LanguageError or ParserErrors returned from parse_and_load.
+    Lower level helper method to collect the definitions to check by calling parse_and_load and handling any LanguageError or ParserErrors returned from parse_and_load.
 
     Args:
         aac_file (str):         The AaC file being processed
@@ -439,7 +439,7 @@ def find_definitions_to_check(aac_file: str) -> (list[Definition], ExecutionStat
                 message="LanguageError from parse_and_load: " + le.message + " at location: " + le.location,
                 level=MessageLevel.DEBUG,
                 source=aac_file,
-                location=None,  # Included in the message above
+                location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
         return (None, ExecutionResult(plugin_name, "check", status, messages))
@@ -459,7 +459,7 @@ def find_definitions_to_check(aac_file: str) -> (list[Definition], ExecutionStat
                 message="ParserError from parse_and_load. " + error_message,
                 level=MessageLevel.DEBUG,
                 source=aac_file,
-                location=None,  # Included in the message above
+                location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
         return (None, ExecutionResult(plugin_name, "check", status, messages))
@@ -492,13 +492,13 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult:
 
     messages = []
 
-    definitions_to_check, executionResult = find_definitions_to_check(aac_file)
+    definitions_to_check, returnedExecutionResult = find_definitions_to_check(aac_file)
 
-    # Check if we got an executionResult back from find_definitions_to_check
+    # Check if we got an returnedExecutionResult back from find_definitions_to_check
     # If we did, we received an exception from parse_and_load, so go ahead
-    # and return that now
-    if executionResult is not None:
-        return executionResult
+    # and return the returnedExecutionResult now
+    if returnedExecutionResult is not None:
+        return returnedExecutionResult
 
     # First run all context constraint checks
     # Context constraints are "language constraints" and are not tied to a specific schema

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -12,6 +12,7 @@ from aac.execute.aac_execution_result import (
     MessageLevel,
 )
 from aac.context.language_error import LanguageError
+from aac.in_out.parser._parser_error import ParserError
 
 plugin_name = "Check AaC"
 
@@ -413,6 +414,56 @@ def _collect_all_constraints_by_name() -> dict[str, Callable]:
     return all_constraints_by_name
 
 
+def find_definitions_to_check(aac_file: str) -> ExecutionResult:
+    """
+    Lower level helper method to call collect the definitions to check by calling parse_and_load and handling any LanguageError or ParserErrors returned from parse_and_load.
+
+    Args:
+        aac_file (str):         The AaC file being processed
+
+    Returns:
+        definitions_to_check:   The list of definitions to check
+        ExecutionResult:        Method result containing: plugin_name ("Check AaC"), "check", status, message
+                                including results from lower level helper methods
+    """
+
+    context: LanguageContext = LanguageContext()
+    messages = []
+    definitions_to_check = []
+    try:
+        definitions_to_check = context.parse_and_load(aac_file)
+    except LanguageError as le:
+        status = ExecutionStatus.CONSTRAINT_FAILURE
+        messages.append(
+            ExecutionMessage(
+                message="LanguageError from parse_and_load: " + le.message + " at location: " + le.location,
+                level=MessageLevel.DEBUG,
+                source=aac_file,
+                location=None,  # Included in the message above
+            )
+        )
+        return (None, ExecutionResult(plugin_name, "check", status, messages))
+    except ParserError as pe:
+        status = ExecutionStatus.PARSER_FAILURE
+
+        error_msg = str(pe.errors)
+        indexBegin = error_msg.find("Encountered error at line, column:")
+        indexEnd = error_msg.find("'", indexBegin)
+
+        print(error_msg)
+        errorLocation = error_msg[indexBegin:indexEnd]
+        messages.append(
+            ExecutionMessage(
+                message="ParserError from parse_and_load." + str(pe.errors),
+                level=MessageLevel.DEBUG,
+                source=aac_file,
+                location=None,  # Included in the message above
+            )
+        )
+        return (None, ExecutionResult(plugin_name, "check", status, messages))
+    return (definitions_to_check, None)
+
+
 def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult:
     """
     Checks relevant constraints for given definition(s).  Runs context constraints (global constraints), then runs schema constraints (specifically assigned constraints). Primitive constraints are ran as a part of schema constraints.
@@ -437,10 +488,15 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult:
     # collect all constraints for easy access
     all_constraints_by_name = _collect_all_constraints_by_name()
 
-    # FIX ME: This call to parse_and_load can throw LanguageError and ParserError exceptions which are not being handled here
-    # FIX ME: They should be handled, their messages added to the message list being constructed in this method (complete with source and location info)
-    # FIX ME: so they can be passed along. This was discovered during the expansion of test_check_aac.py and those tests would need to be updated.
-    definitions_to_check = context.parse_and_load(aac_file)
+    messages = []
+
+    definitions_to_check, executionResult = find_definitions_to_check(aac_file)
+
+    # Check if we got an executionResult back from find_definitions_to_check
+    # If we did, we received an exception from parse_and_load, so go ahead
+    # and return that now
+    if executionResult is not None:
+        return executionResult
 
     # First run all context constraint checks
     # Context constraints are "language constraints" and are not tied to a specific schema

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -414,7 +414,7 @@ def _collect_all_constraints_by_name() -> dict[str, Callable]:
     return all_constraints_by_name
 
 
-def find_definitions_to_check(aac_file: str) -> ExecutionResult:
+def find_definitions_to_check(aac_file: str) -> (list, ExecutionStatus):
     """
     Lower level helper method to call collect the definitions to check by calling parse_and_load and handling any LanguageError or ParserErrors returned from parse_and_load.
 
@@ -422,7 +422,7 @@ def find_definitions_to_check(aac_file: str) -> ExecutionResult:
         aac_file (str):         The AaC file being processed
 
     Returns:
-        definitions_to_check:   The list of definitions to check
+        definitions_to_check[]: The list of definitions to check
         ExecutionResult:        Method result containing: plugin_name ("Check AaC"), "check", status, message
                                 including results from lower level helper methods
     """

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -446,15 +446,17 @@ def find_definitions_to_check(aac_file: str) -> ExecutionResult:
     except ParserError as pe:
         status = ExecutionStatus.PARSER_FAILURE
 
-        error_msg = str(pe.errors)
-        indexBegin = error_msg.find("Encountered error at line, column:")
-        indexEnd = error_msg.find("'", indexBegin)
+        # Construct error message, we should have at least 2 entries in the list
+        # but let's make sure first. If we only have one entry then use that.
+        error_message = ""
+        if len(pe.errors) > 1:
+            error_message = str(pe.errors[0]) + str(pe.errors[1])
+        elif len(pe.errors) == 1:
+            error_message = str(pe.errors[0])
 
-        print(error_msg)
-        errorLocation = error_msg[indexBegin:indexEnd]
         messages.append(
             ExecutionMessage(
-                message="ParserError from parse_and_load." + str(pe.errors),
+                message="ParserError from parse_and_load. " + error_message,
                 level=MessageLevel.DEBUG,
                 source=aac_file,
                 location=None,  # Included in the message above

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -492,10 +492,11 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult:
 
     messages = []
 
+    # collect all the definitions to check
     definitions_to_check, returnedExecutionResult = find_definitions_to_check(aac_file)
 
-    # Check if we got an returnedExecutionResult back from find_definitions_to_check
-    # If we did, we received an exception from parse_and_load, so go ahead
+    # Check if we received a returnedExecutionResult back from find_definitions_to_check
+    # If we did, then we received an exception from parse_and_load, so go ahead
     # and return the returnedExecutionResult now
     if returnedExecutionResult is not None:
         return returnedExecutionResult

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -414,7 +414,7 @@ def _collect_all_constraints_by_name() -> dict[str, Callable]:
     return all_constraints_by_name
 
 
-def find_definitions_to_check(aac_file: str) -> (list, ExecutionStatus):
+def find_definitions_to_check(aac_file: str) -> (list[Definition], ExecutionStatus):
     """
     Lower level helper method to call collect the definitions to check by calling parse_and_load and handling any LanguageError or ParserErrors returned from parse_and_load.
 
@@ -422,7 +422,7 @@ def find_definitions_to_check(aac_file: str) -> (list, ExecutionStatus):
         aac_file (str):         The AaC file being processed
 
     Returns:
-        definitions_to_check[]: The list of definitions to check
+        list[Definition]:       The list of definitions to check
         ExecutionResult:        Method result containing: plugin_name ("Check AaC"), "check", status, message
                                 including results from lower level helper methods
     """

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -493,13 +493,13 @@ def check(aac_file: str, fail_on_warn: bool, verbose: bool) -> ExecutionResult:
     messages = []
 
     # collect all the definitions to check
-    definitions_to_check, returnedExecutionResult = find_definitions_to_check(aac_file)
+    definitions_to_check, returned_execution_result = find_definitions_to_check(aac_file)
 
-    # Check if we received a returnedExecutionResult back from find_definitions_to_check
+    # Check if we received a returned_execution_result back from find_definitions_to_check
     # If we did, then we received an exception from parse_and_load, so go ahead
-    # and return the returnedExecutionResult now
-    if returnedExecutionResult is not None:
-        return returnedExecutionResult
+    # and return the returned_execution_result now
+    if returned_execution_result is not None:
+        return returned_execution_result
 
     # First run all context constraint checks
     # Context constraints are "language constraints" and are not tied to a specific schema

--- a/python/tests/test_aac/plugins/check/test_check_aac.py
+++ b/python/tests/test_aac/plugins/check/test_check_aac.py
@@ -26,7 +26,6 @@ class TestCheckAaC(TestCase):
         exit_code = result.exit_code
         std_out = str(result.stdout)
         output_message = std_out.strip().replace("\x1b[0m", "")
-        # print(output_message)
         return exit_code, output_message
 
     # Happy path test without verbose flag
@@ -110,7 +109,6 @@ class TestCheckAaC(TestCase):
             self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
             self.assertIn("LanguageError from parse_and_load: Missing required field when.", output_message)
-
 
     # Test input with an unknown primitive "stranger" which triggers a ParserError
     # output msg: Found undefined field name 'stranger' when expecting ['name', 'tags', 'requirements', 'given', 'when', 'then', 'examples'] as defined in Scenario

--- a/python/tests/test_aac/plugins/check/test_check_aac.py
+++ b/python/tests/test_aac/plugins/check/test_check_aac.py
@@ -10,8 +10,6 @@ import tempfile
 
 class TestCheckAaC(TestCase):
     """Class to test the Check AaC plugin."""
-    # FIX ME: Several tests in this class should be updated when the LanguageError and ParserError exceptions thrown by the check_aac_impl.py call to
-    # FIX ME: parse_and_load are handled properly.
 
     # some default test
     def test_check(self):
@@ -28,6 +26,7 @@ class TestCheckAaC(TestCase):
         exit_code = result.exit_code
         std_out = str(result.stdout)
         output_message = std_out.strip().replace("\x1b[0m", "")
+        # print(output_message)
         return exit_code, output_message
 
     # Happy path test without verbose flag
@@ -64,8 +63,6 @@ class TestCheckAaC(TestCase):
 
     # Test input triggers a LanguageError in check_aac_impl.py ~line 171
     # Value of 'parent_specs' was expected to be list, but was '<class 'str'>'
-    # This test should be looking for a LanguageError or message content from a LanguageError but the exceptions from context.parse_and_load(aac_file)
-    # in check_aac_imply.py are not being caught and handled gracefully.
     def test_cli_check_bad_data(self):
         """Test check_aac_impl.py and trigger a LanguageError."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -82,8 +79,6 @@ class TestCheckAaC(TestCase):
 
     # Test input improper YAML
     # output msg: The AaC file '/tmp/{random-temp-name}/my_plugin.aac' could not be parsed.
-    # This test should be looking for a ParserError or message content from a ParserError but the exceptions from context.parse_and_load(aac_file)
-    # in check_aac_imply.py are not being caught and handled gracefully.
     def test_parse_Error(self):
         """Test check_aac_impl.py with improper YAML."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -94,11 +89,10 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 3 (fail)
+            # Assert for return code 3 (3 is the value for PARSER_FAILURE which is the status set upon receiving a ParserError)
             self.assertEqual(3, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
             self.assertIn("Encountered an invalid YAML with the following scanner error", output_message)
-            print(output_message)
 
     # Test input missing required 'when' field primitive
     # output msg: Missing required field when.
@@ -112,7 +106,7 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 1 (missing required field)
+            # Assert for return code 1 (1 is the value for CONSTRAINT_FAILURE which is the status set upon receiving a LanguageError)
             self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
             self.assertIn("LanguageError from parse_and_load: Missing required field when.", output_message)
@@ -120,8 +114,6 @@ class TestCheckAaC(TestCase):
 
     # Test input with an unknown primitive "stranger" which triggers a ParserError
     # output msg: Found undefined field name 'stranger' when expecting ['name', 'tags', 'requirements', 'given', 'when', 'then', 'examples'] as defined in Scenario
-    # This test should be looking for a ParserError or message content from a ParserError but the exceptions from context.parse_and_load(aac_file)
-    # in check_aac_imply.py are not being caught and handled gracefully.
     def test_unknown_primitive(self):
         """Test check_aac_impl.py with an unknown primitive resulting in a ParserError."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -132,7 +124,7 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 1 (unexpected primitive)
+            # Assert for return code 1 (1 is the value for CONSTRAINT_FAILURE which is the status set upon receiving a LanguageError)
             self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
             self.assertIn("LanguageError from parse_and_load: Found undefined field name 'stranger'", output_message)
@@ -166,7 +158,7 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 1 (undefined field name)
+            # Assert for return code 1 (1 is the value for CONSTRAINT_FAILURE which is the status set upon receiving a LanguageError)
             self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
             self.assertIn("LanguageError from parse_and_load: Found undefined field name 'whatzit'", output_message)

--- a/python/tests/test_aac/plugins/check/test_check_aac.py
+++ b/python/tests/test_aac/plugins/check/test_check_aac.py
@@ -97,8 +97,8 @@ class TestCheckAaC(TestCase):
             # Assert for return code 3 (fail)
             self.assertEqual(3, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
-            self.assertIn("my_plugin.aac", output_message)
-            self.assertIn("invalid YAML", output_message)
+            self.assertIn("Encountered an invalid YAML with the following scanner error", output_message)
+            print(output_message)
 
     # Test input missing required 'when' field primitive
     # output msg: Missing required field when.
@@ -112,10 +112,10 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 6 (missing required field)
-            self.assertEqual(6, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
+            # Assert for return code 1 (missing required field)
+            self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
-            self.assertIn("Missing required field when.", output_message)
+            self.assertIn("LanguageError from parse_and_load: Missing required field when.", output_message)
 
 
     # Test input with an unknown primitive "stranger" which triggers a ParserError
@@ -132,10 +132,10 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 6 (unexpected primitive)
-            self.assertEqual(6, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
+            # Assert for return code 1 (unexpected primitive)
+            self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
-            self.assertIn("my_plugin.aac", output_message)
+            self.assertIn("LanguageError from parse_and_load: Found undefined field name 'stranger'", output_message)
 
     # Test input with an an invalid value
     # output msg: Invalid value for field 'name'.  Expected type 'str', but found '<class 'list'>'
@@ -149,10 +149,10 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 6 (invalid value)
-            self.assertEqual(6, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
+            # Assert for return code 1 (invalid value)
+            self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
-            self.assertIn("Invalid value for field", output_message)
+            self.assertIn("LanguageError from parse_and_load: Invalid value for field 'name'", output_message)
 
     # Test input with an an undefined field name "whatzit"
     # output msg: Found undefined field name 'whatzit' when expecting ['name', 'description', 'sections', 'parent_specs', 'child_specs', 'requirements'] as defined in RequirementSpecification
@@ -166,7 +166,7 @@ class TestCheckAaC(TestCase):
             check_args = [temp_aac_file_path]
 
             exit_code, output_message = self.run_check_cli_command_with_args(check_args)
-            # Assert for return code 6 (undefined field name)
-            self.assertEqual(6, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
+            # Assert for return code 1 (undefined field name)
+            self.assertEqual(1, exit_code, f"Expected to fail but ran successfully with message: {output_message}")
             self.assertNotIn("My plugin was successful.", output_message)  # only appears when --verbose is passed in.
-            self.assertIn("my_plugin.aac", output_message)
+            self.assertIn("LanguageError from parse_and_load: Found undefined field name 'whatzit'", output_message)


### PR DESCRIPTION
# Description

Updated check_aac_impl.py check method to handle exceptions from the parse_and_load call. In order to keep complexity down the call parse_and_load and the exception handling was moved into a new find_definitions_to_check method.

# Linked Items:

Closes <https://github.com/DevOps-MBSE/AaC/issues/968>

### Added

- Updated check_aac_impl.py check method to handle exceptions from the parse_and_load call.
- In order to keep complexity down the call parse_and_load and the exception handling was moved into a new find_definitions_to_check method.
- Unit tests in test_check_aac.py were updated to look for updated exit codes and output messages.

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
