### PR TITLE
Adccs 2994 parse and load error handling

### DIFF
--- a/.github/workflows/python-build-and-lint.yml
+++ b/.github/workflows/python-build-and-lint.yml
@@ -62,7 +62,9 @@ jobs:
           path: |
             python/docs/doc_artifacts/api
             python/docs/doc_artifacts/project_documentation
-      
+
+      # Commented out since the Build PDF step in the Python Build/Build Artifacts was failing for an unknown reason. This failure was also
+      # occuring in the main pre-branch area.
       # - name: Build PDF
       #   run: |
       #     make -C ../docs/ simplepdf

--- a/.github/workflows/python-build-and-lint.yml
+++ b/.github/workflows/python-build-and-lint.yml
@@ -63,13 +63,13 @@ jobs:
             python/docs/doc_artifacts/api
             python/docs/doc_artifacts/project_documentation
       
-      - name: Build PDF
-        run: |
-          make -C ../docs/ simplepdf
+      # - name: Build PDF
+      #   run: |
+      #     make -C ../docs/ simplepdf
 
-      - name: Upload PDF
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}_${{steps.package-version.outputs.VERSION_STRING}}_documentation-pdf
-          path: |
-            docs/docs/simplepdf/Architecture-as-Code.pdf
+      # - name: Upload PDF
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ github.event.repository.name }}_${{steps.package-version.outputs.VERSION_STRING}}_documentation-pdf
+      #     path: |
+      #       docs/docs/simplepdf/Architecture-as-Code.pdf

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
-        os: [ubuntu-20.04, ubuntu-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
+        os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
 
     steps:
       - name: Checkout Repository
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
-        os: [ubuntu-20.04, ubuntu-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
+        os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-14] # Annoyingly, Github actions don't support anchors
         py_version: ["3.11.7"]   # py_version: ["3.9.0", "3.10.0", "3.11.0"]
         # exclude:
         #   - os: ubuntu-latest

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.5.20"
+__version__ = "0.5.21"
 
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -893,6 +893,10 @@ class DefinitionParser():
 
         Returns:
             The parsed definitions to load into the LanguageContext.
+
+        Raises:
+            JSW
+            LanguageError: From set_qualified_name (line 913), create_definition_instance (line 922)
         """
 
         # Maintainer note:  Yes, this function is a bit of a monster...sorry about that.

--- a/python/src/aac/context/definition_parser.py
+++ b/python/src/aac/context/definition_parser.py
@@ -895,8 +895,7 @@ class DefinitionParser():
             The parsed definitions to load into the LanguageContext.
 
         Raises:
-            JSW
-            LanguageError: From set_qualified_name (line 913), create_definition_instance (line 922)
+            LanguageError: From set_qualified_name and create_definition_instance
         """
 
         # Maintainer note:  Yes, this function is a bit of a monster...sorry about that.

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -178,7 +178,7 @@ class LanguageContext(object):
             IOError: Exception from _read_arch_file_content
             Exception: Generic exception from _read_arch_file_content
         """
-        parsed_definitions = parse(arg) ## OK
+        parsed_definitions = parse(arg)
         parser = DefinitionParser()
 
         return parser.load_definitions(self, parsed_definitions)

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -169,8 +169,17 @@ class LanguageContext(object):
 
         Returns:
             A list of definition objects which have been loaded into the Language Context.
+
+        Raises:
+            JSW
+            LanguageError: parse()->_parse_file()->_read_arch_file_content()
+            see /src/aac/plugins/check/check_aac_impl.py line 435
+            ParserError: parse()->_parse_file()->_read_arch_file_content()
+             see /src/aac/plugins/check/check_aac_impl.py line 446
+            IOError: Exception from _read_arch_file_content
+            Exception: Generic exception from _read_arch_file_content
         """
-        parsed_definitions = parse(arg)
+        parsed_definitions = parse(arg) ## OK
         parser = DefinitionParser()
 
         return parser.load_definitions(self, parsed_definitions)

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -171,7 +171,6 @@ class LanguageContext(object):
             A list of definition objects which have been loaded into the Language Context.
 
         Raises:
-            JSW
             LanguageError: parse()->_parse_file()->_read_arch_file_content()
             see /src/aac/plugins/check/check_aac_impl.py line 435
             ParserError: parse()->_parse_file()->_read_arch_file_content()

--- a/python/src/aac/context/language_context.py
+++ b/python/src/aac/context/language_context.py
@@ -172,9 +172,7 @@ class LanguageContext(object):
 
         Raises:
             LanguageError: parse()->_parse_file()->_read_arch_file_content()
-            see /src/aac/plugins/check/check_aac_impl.py line 435
             ParserError: parse()->_parse_file()->_read_arch_file_content()
-             see /src/aac/plugins/check/check_aac_impl.py line 446
             IOError: Exception from _read_arch_file_content
             Exception: Generic exception from _read_arch_file_content
         """

--- a/python/src/aac/plugins/check/check_aac_impl.py
+++ b/python/src/aac/plugins/check/check_aac_impl.py
@@ -423,8 +423,7 @@ def find_definitions_to_check(aac_file: str) -> (list[Definition], ExecutionStat
 
     Returns:
         list[Definition]:       The list of definitions to check
-        ExecutionResult:        Method result containing: plugin_name ("Check AaC"), "check", status, message
-                                including results from lower level helper methods
+        ExecutionResult:        Method result containing: plugin_name ("Check AaC"), "check", status, message including results from lower level helper methods
     """
 
     context: LanguageContext = LanguageContext()

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -355,19 +355,7 @@ def generate(
             )
         )
         return (None, ExecutionResult(plugin_name, "check", status, messages))
-    except IOError as ie:
-        status = ExecutionStatus.GENERAL_FAILURE
-
-        messages.append(
-            ExecutionMessage(
-                message="IOError from parse_and_load. " + ie.message,
-                level=MessageLevel.DEBUG,
-                source=aac_file,
-                location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
-            )
-        )
-        return (None, ExecutionResult(plugin_name, "check", status, messages))
-    except Exception as ex:
+    except Exception as ex:  # Also catching IOError but we don't do anything special handling for IOError so handle it here
         status = ExecutionStatus.GENERAL_FAILURE
 
         messages.append(

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -309,7 +309,7 @@ def generate(
 
     # setup definition lists
     parsed_definitions = []
-    generator_definitions = []  # This may be the last line of code I ever get paid to write JSW
+    generator_definitions = []  # This may be the last line of code I ever get paid to write JSW 08APR2025
 
     # setup directories
     code_out_dir = ""

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -348,7 +348,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "check", status, messages))
+        return (None, ExecutionResult(plugin_name, "generate", status, messages))
     except ParserError as pe:
         status = ExecutionStatus.PARSER_FAILURE
 
@@ -360,7 +360,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "check", status, messages))
+        return (None, ExecutionResult(plugin_name, "generate", status, messages))
     except Exception as ex:  # Also catching IOError but we don't do anything special handling for IOError so handle it here
         status = ExecutionStatus.GENERAL_FAILURE
 
@@ -372,7 +372,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "check", status, messages))
+        return (None, ExecutionResult(plugin_name, "generate", status, messages))
 
     # go through each generator in the parsed_definitions
     for definition in generator_definitions:

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -348,7 +348,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "generate", status, messages))
+        return (ExecutionResult(plugin_name, "generate", status, messages))
     except ParserError as pe:
         status = ExecutionStatus.PARSER_FAILURE
 
@@ -360,7 +360,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "generate", status, messages))
+        return (ExecutionResult(plugin_name, "generate", status, messages))
     except Exception as ex:  # Also catching IOError but we don't do anything special handling for IOError so handle it here
         status = ExecutionStatus.GENERAL_FAILURE
 
@@ -372,7 +372,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (None, ExecutionResult(plugin_name, "generate", status, messages))
+        return (ExecutionResult(plugin_name, "generate", status, messages))
 
     # go through each generator in the parsed_definitions
     for definition in generator_definitions:

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -304,6 +304,13 @@ def generate(
 
     result = ExecutionResult(plugin_name, "generate", ExecutionStatus.SUCCESS, [])
 
+    # setup return messages
+    messages = []
+
+    # setup definition lists
+    parsed_definitions = []
+    generator_definitions = []  # This may be the last line of code I ever get paid to write JSW
+
     # setup directories
     code_out_dir = ""
     test_out_dir = ""
@@ -325,13 +332,12 @@ def generate(
     # build out properties
     # the templates need data from the plugin model to generate code
     context = LanguageContext()
-    parsed_definitions = parse(
-        aac_file
-    )  # we only want to parse, not load, to avoid chicken and egg issues
 
-    messages = []
     try:
-        generator_definitions = context.parse_and_load(generator_file)
+        parsed_definitions = parse(
+            aac_file
+        )  # we only want to parse, not load, to avoid chicken and egg issues
+        generator_definitions = context.parse_and_load(generator_file)  # Now we want to parse and load for real
     except LanguageError as le:
         status = ExecutionStatus.CONSTRAINT_FAILURE
         messages.append(

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -348,7 +348,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (ExecutionResult(plugin_name, "generate", status, messages))
+        return ExecutionResult(plugin_name, "generate", status, messages)
     except ParserError as pe:
         status = ExecutionStatus.PARSER_FAILURE
 
@@ -360,7 +360,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (ExecutionResult(plugin_name, "generate", status, messages))
+        return ExecutionResult(plugin_name, "generate", status, messages)
     except Exception as ex:  # Also catching IOError but we don't do anything special handling for IOError so handle it here
         status = ExecutionStatus.GENERAL_FAILURE
 
@@ -372,7 +372,7 @@ def generate(
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
             )
         )
-        return (ExecutionResult(plugin_name, "generate", status, messages))
+        return ExecutionResult(plugin_name, "generate", status, messages)
 
     # go through each generator in the parsed_definitions
     for definition in generator_definitions:

--- a/python/src/aac/plugins/generate/generate_impl.py
+++ b/python/src/aac/plugins/generate/generate_impl.py
@@ -329,8 +329,6 @@ def generate(
         aac_file
     )  # we only want to parse, not load, to avoid chicken and egg issues
 
-    # JSW
-    # TO DO Consider surrounding this call to parse_and_load with a try except block to catch and handle the various exceptions that can be thrown
     messages = []
     try:
         generator_definitions = context.parse_and_load(generator_file)
@@ -351,6 +349,30 @@ def generate(
         messages.append(
             ExecutionMessage(
                 message="ParserError from parse_and_load. " + process_parser_error(pe),
+                level=MessageLevel.DEBUG,
+                source=aac_file,
+                location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
+            )
+        )
+        return (None, ExecutionResult(plugin_name, "check", status, messages))
+    except IOError as ie:
+        status = ExecutionStatus.GENERAL_FAILURE
+
+        messages.append(
+            ExecutionMessage(
+                message="IOError from parse_and_load. " + ie.message,
+                level=MessageLevel.DEBUG,
+                source=aac_file,
+                location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.
+            )
+        )
+        return (None, ExecutionResult(plugin_name, "check", status, messages))
+    except Exception as ex:
+        status = ExecutionStatus.GENERAL_FAILURE
+
+        messages.append(
+            ExecutionMessage(
+                message="Exception from parse_and_load. " + ex.message,
                 level=MessageLevel.DEBUG,
                 source=aac_file,
                 location=None,  # Included in the message above. Their type/format is not easily compatible with the SourceLocation needed here.

--- a/python/tests/test_aac/plugins/gen_plugin/bad.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/bad.aac
@@ -1,0 +1,4 @@
+req_spec:
+  name: "req4_2_2"
+  description: "MSPSP Preparation. Requirements for preparing an MSPSP can be found in Attachment 2 of this volume. SSCMAN91_710_3 27 DECEMBER 2_22_13"
+  parent_specs: "SSCMAN91_710_3_27_DECEMBER_2_22_13"

--- a/python/tests/test_aac/plugins/gen_plugin/invalid_value.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/invalid_value.aac
@@ -1,0 +1,75 @@
+plugin:
+  name: My plugin
+  package: happy
+  description: |
+    An AaC plugin definition used to test the gen-plugin command behavior.
+  commands:
+    - name: test-command
+      help_text: |
+        A test command used to test the gen-plugin command behavior.
+      run_before:
+        - plugin: Check AaC
+          command: check
+      run_after:
+        - plugin: Generate
+          command: generate
+      input:
+        - name: aac-plugin-file
+          type: file
+          description: The path to the architecture file with the plugin definition.
+      acceptance:
+        - name: Command test
+          scenarios:
+            - name:
+                - Simple
+                - Command
+                - Test
+              given:
+                - A1 An AaC file containing schemas with no extra fields.
+              given:
+                - A11 An AaC file containing schemas with no extra fields.
+              when:
+                - A2 The AaC check command is run on the schema.
+              then:
+                - A3 The check commands provides the output 'All AaC constraint checks were successful.'
+  context_constraints:
+    - name: The sky is blue
+      description: Ensures the sky is blue.
+      acceptance:
+        - name: Context test
+          scenarios:
+            - name: Simple Constraint Test
+              given:
+                - B1 An AaC file containing schemas with no extra fields.
+              when:
+                - B2 The AaC check command is run on the schema.
+              then:
+                - B3 The check commands provides the output 'All AaC constraint checks were successful.'
+  schema_constraints:
+    - name: Schemas have happy names
+      description: Check every schema declared provides positive vibes.
+      universal: true
+      acceptance:
+        - name: Schema test
+          scenarios:
+            - name: Simple Schema Test
+              given:
+                - C1 An AaC file containing schemas with no extra fields.
+              when:
+                - C2 The AaC check command is run on the schema.
+              then:
+                - C3 The check commands provides the output 'All AaC constraint checks were successful.'
+  primitive_constraints:
+    - name: Primitives have happy names
+      description: Check every primitive declared provides positive vibes.
+      acceptance:
+        - name: Primitive test
+          scenarios:
+            - name: Simple Primitive Test
+              given:
+                - D1 An AaC file containing schemas with no extra fields.
+              when:
+                - D2 The AaC check command is run on the schema.
+              then:
+                - D3 The check commands provides the output 'All AaC constraint checks were successful.'
+

--- a/python/tests/test_aac/plugins/gen_plugin/missing_required_field.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/missing_required_field.aac
@@ -1,0 +1,67 @@
+plugin:
+  name: My plugin
+  package: happy
+  description: |
+    An AaC plugin definition used to test the gen-plugin command behavior.
+  commands:
+    - name: test-command
+      help_text: |
+        A test command used to test the gen-plugin command behavior.
+      run_before:
+        - plugin: Check AaC
+          command: check
+      run_after:
+        - plugin: Generate
+          command: generate
+      input:
+        - name: aac-plugin-file
+          type: file
+          description: The path to the architecture file with the plugin definition.
+      acceptance:
+        - name: Command test
+          scenarios:
+            - name: Simple Command Test
+              given:
+                - A1 An AaC file containing schemas with no extra fields.
+              then:
+                - A3 The check commands provides the output 'All AaC constraint checks were successful.'
+  context_constraints:
+    - name: The sky is blue
+      description: Ensures the sky is blue.
+      acceptance:
+        - name: Context test
+          scenarios:
+            - name: Simple Constraint Test
+              given:
+                - B1 An AaC file containing schemas with no extra fields.
+              when:
+                - B2 The AaC check command is run on the schema.
+              then:
+                - B3 The check commands provides the output 'All AaC constraint checks were successful.'
+  schema_constraints:
+    - name: Schemas have happy names
+      description: Check every schema declared provides positive vibes.
+      universal: true
+      acceptance:
+        - name: Schema test
+          scenarios:
+            - name: Simple Schema Test
+              given:
+                - C1 An AaC file containing schemas with no extra fields.
+              when:
+                - C2 The AaC check command is run on the schema.
+              then:
+                - C3 The check commands provides the output 'All AaC constraint checks were successful.'
+  primitive_constraints:
+    - name: Primitives have happy names
+      description: Check every primitive declared provides positive vibes.
+      acceptance:
+        - name: Primitive test
+          scenarios:
+            - name: Simple Primitive Test
+              given:
+                - D1 An AaC file containing schemas with no extra fields.
+              when:
+                - D2 The AaC check command is run on the schema.
+              then:
+                - D3 The check commands provides the output 'All AaC constraint checks were successful.'

--- a/python/tests/test_aac/plugins/gen_plugin/parse_error.aac
+++ b/python/tests/test_aac/plugins/gen_plugin/parse_error.aac
@@ -1,0 +1,72 @@
+plugin:
+  name: My plugin
+  package: happy
+  description: |
+    An AaC plugin definition used to test the gen-plugin command behavior.
+  commands:
+    - name: test-command
+      help_text: |
+        A test command used to test the gen-plugin command behavior.
+      run_before:
+        - plugin: Check AaC
+          command: check
+      run_after:
+        - plugin: Generate
+          command: generate
+      input:
+        - name: aac-plugin-file
+          type: file
+          description: The path to the architecture file with the plugin definition.
+      acceptance:
+        - name: Command test
+          scenarios:
+            - name: Simple Command Test
+              given:
+                - A1 An AaC file containing schemas with no extra fields.
+                - A2 A2 A2 A2
+                A3 A3
+              when:
+                - A2 The AaC check command is run on the schema.
+              then:
+                - A3 The check commands provides the output 'All AaC constraint checks were successful.'
+  context_constraints:
+    - name: The sky is blue
+      description: Ensures the sky is blue.
+      acceptance:
+        - name: Context test
+          scenarios:
+            - name: Simple Constraint Test
+              given:
+                - B1 An AaC file containing schemas with no extra fields.
+              when:
+                - B2 The AaC check command is run on the schema.
+              then:
+                - B3 The check commands provides the output 'All AaC constraint checks were successful.'
+  schema_constraints:
+    - name: Schemas have happy names
+      description: Check every schema declared provides positive vibes.
+      universal: true
+      acceptance:
+        - name: Schema test
+          scenarios:
+            - name: Simple Schema Test
+              given:
+                - C1 An AaC file containing schemas with no extra fields.
+              when:
+                - C2 The AaC check command is run on the schema.
+              then:
+                - C3 The check commands provides the output 'All AaC constraint checks were successful.'
+  primitive_constraints:
+    - name: Primitives have happy names
+      description: Check every primitive declared provides positive vibes.
+      acceptance:
+        - name: Primitive test
+          scenarios:
+            - name: Simple Primitive Test
+              given:
+                - D1 An AaC file containing schemas with no extra fields.
+              when:
+                - D2 The AaC check command is run on the schema.
+              then:
+                - D3 The check commands provides the output 'All AaC constraint checks were successful.'
+

--- a/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
+++ b/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
@@ -405,7 +405,7 @@ class TestGenPlugin(TestCase):
             file.close()
 
 
-    # Test input triggers a LanguageError in check_aac_impl.py
+    # Test input triggers a LanguageError
     # Value of 'parent_specs' was expected to be list, but was '<class 'str'>'
     # See src/tests/test_aac/plugins/check/test_check_aac.py test_cli_check_bad_data method for a sibling method
     def test_cli_gen_plugin_bad_data(self):

--- a/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
+++ b/python/tests/test_aac/plugins/gen_plugin/test_gen_plugin.py
@@ -405,7 +405,7 @@ class TestGenPlugin(TestCase):
             file.close()
 
 
-    # Test input triggers a LanguageError in check_aac_impl.py ~line 171
+    # Test input triggers a LanguageError in check_aac_impl.py
     # Value of 'parent_specs' was expected to be list, but was '<class 'str'>'
     # See src/tests/test_aac/plugins/check/test_check_aac.py test_cli_check_bad_data method for a sibling method
     def test_cli_gen_plugin_bad_data(self):


### PR DESCRIPTION
# Description

Updated generate_impl.py generate method to handle exceptions from the parse and parse_and_load calls. In order to keep complexity down the calls to parse and parse_and_load were moved into the same try block. 

# Linked Items:

Closes <https://github.com/DevOps-MBSE/AaC/issues/969>

### Added

- Updated generate_impl.py generate method to handle exceptions from the parse and parse_and_load calls.
- In order to keep complexity down the calls to parse and parse_and_load were moved into the same try block. 
- Unit tests in test_gen_plugin.py were updated to look for updated exit codes and output messages.
- Docstring in language_context.py parse_and_load method updated to document raises exceptions.
- Docstring in definition_parser.py load_definitions method updated to document raises exception.

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [x] My changes generate no new warnings.
- [x] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
